### PR TITLE
[ファーム対応] FIDO BLEサービスの開通（PING）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ core
 .vscode
 
 # ignore for Zephyr
+build
 build_signed

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -496,7 +496,3 @@ bool fido_ble_receive_control_point(uint8_t *data, size_t size)
         return false;
     }
 }
-
-void fido_ble_receive_on_request_received(void)
-{
-}

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -5,12 +5,36 @@
  * Created on 2023/05/10, 17:05
  */
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
-bool fido_ble_receive_control_point(uint8_t *data, uint16_t length)
+#include "wrapper_common.h"
+
+// for debug hex dump data
+#define NRF_LOG_HEXDUMP_DEBUG_PACKET        false
+
+// u2f control point（コマンドバッファ）には、64バイトまで書込み可能とします
+static uint8_t control_point_buffer[64];
+static size_t  control_point_buffer_length;
+
+//
+// 公開用関数
+//
+bool fido_ble_receive_control_point(uint8_t *data, size_t size)
 {
+    // U2Fクライアントから受信したリクエストデータを、内部バッファに保持
+    memcpy(control_point_buffer, data, size);
+    control_point_buffer_length = size;
+
+#if NRF_LOG_HEXDUMP_DEBUG_PACKET
+    fido_log_debug("U2F control point buffer (%u bytes):", control_point_buffer_length);
+    fido_log_print_hexdump_debug(control_point_buffer, control_point_buffer_length);
+#endif
+
     return false;
 }
+
 void fido_ble_receive_on_request_received(void)
 {
 }

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -11,12 +11,77 @@
 
 #include "wrapper_common.h"
 
+#include "fido_define.h"
+#include "fido_transport_define.h"
+
 // for debug hex dump data
 #define NRF_LOG_HEXDUMP_DEBUG_PACKET        false
+
+//
+// 内部処理
+//
+static void set_u2f_command_error(FIDO_COMMAND_T *p_command, uint8_t ERROR)
+{
+    p_command->CMD   = (U2F_COMMAND_ERROR | 0x80);
+    p_command->ERROR = ERROR;
+}
+
+static bool is_u2f_command_error(FIDO_COMMAND_T *p_command)
+{
+    return p_command->CMD == (U2F_COMMAND_ERROR | 0x80);
+}
+
+static bool is_apdu_size_overflow(FIDO_APDU_T *p_apdu)
+{
+    if (p_apdu->data_length > p_apdu->Lc) {
+        fido_log_error("apdu data length(%d) exceeds Lc(%d) ", p_apdu->data_length, p_apdu->Lc);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static bool is_apdu_received_completely(FIDO_APDU_T *p_apdu)
+{
+    if (p_apdu->data_length == p_apdu->Lc) {
+#if NRF_LOG_HEXDUMP_DEBUG_PACKET
+        fido_log_debug("apdu data received(%d bytes)", p_apdu->data_length);
+#endif
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static bool is_initialization_packet(uint8_t first_byte)
+{
+    return (first_byte & 0x80);
+}
+
+static void u2f_request_receive_leading_packet(FIDO_COMMAND_T *p_command, FIDO_APDU_T *p_apdu)
+{
+    // コマンドとAPDUを初期化
+    memset(p_command, 0, sizeof(FIDO_COMMAND_T));
+    memset(p_apdu,    0, sizeof(FIDO_APDU_T));
+
+    // TODO: 仮の実装です。
+    fido_log_error("INIT frame process not implemented");
+}
+
+static void u2f_request_receive_following_packet(FIDO_COMMAND_T *p_command, FIDO_APDU_T *p_apdu)
+{
+    // TODO: 仮の実装です。
+    fido_log_error("CONT frame process not implemented");
+}
 
 // u2f control point（コマンドバッファ）には、64バイトまで書込み可能とします
 static uint8_t control_point_buffer[64];
 static size_t  control_point_buffer_length;
+
+// リクエストデータに含まれるBLEコマンド、APDU項目は
+// このモジュール内で保持
+static FIDO_COMMAND_T m_command;
+static FIDO_APDU_T    m_apdu;
 
 //
 // 公開用関数
@@ -32,7 +97,33 @@ bool fido_ble_receive_control_point(uint8_t *data, size_t size)
     fido_log_print_hexdump_debug(control_point_buffer, control_point_buffer_length);
 #endif
 
-    return false;
+    if (is_initialization_packet(control_point_buffer[0])) {
+        // 先頭パケットに対する処理を行う
+        u2f_request_receive_leading_packet(&m_command, &m_apdu);
+    } else {
+        // 後続パケットに対する処理を行う
+        u2f_request_receive_following_packet(&m_command, &m_apdu);
+    }
+
+    if (is_apdu_size_overflow(&m_apdu)) {
+        // データヘッダー設定されたデータ長が不正の場合
+        // エラーレスポンスメッセージを作成
+        set_u2f_command_error(&m_command, CTAP1_ERR_INVALID_LENGTH);
+    }
+
+    if (is_apdu_received_completely(&m_apdu)) {
+        // 全ての受信データが完備したらtrueを戻す
+        return true;
+
+    } else if (is_u2f_command_error(&m_command)) {
+        // リクエストデータの検査中にエラーが確認された場合、
+        // エラーレスポンス実行のため、trueを戻す
+        return true;
+
+    } else {
+        // データが完備していなければfalseを戻す
+        return false;
+    }
 }
 
 void fido_ble_receive_on_request_received(void)

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -299,7 +299,7 @@ static void extract_request_from_initialization_packet(uint8_t *control_point_bu
     if (control_point_buffer_length < 3) {
         // 受取ったバイト数が３バイトに満たない場合は、
         // リクエストとして成立しないので終了
-        fido_log_error("u2f_request_receive: invalid request ");
+        fido_log_error("Received invalid request (%d bytes)", control_point_buffer_length);
         set_u2f_command_error(p_command, CTAP1_ERR_INVALID_LENGTH);
         return;
     }
@@ -321,7 +321,7 @@ static void extract_request_from_initialization_packet(uint8_t *control_point_bu
     uint8_t command = get_u2f_command_byte(p_command);
     if (is_valid_fido_command(command) == false) {
         // 設定されたコマンドが不正の場合、ここで処理を終了
-        fido_log_error("u2f_request_receive: invalid command (0x%02x) ", command);
+        fido_log_error("Received invalid command (0x%02x) ", command);
         set_u2f_command_error(p_command, CTAP1_ERR_INVALID_COMMAND);
         return;
     }
@@ -335,7 +335,7 @@ static void extract_request_from_initialization_packet(uint8_t *control_point_bu
 
 #if NRF_LOG_DEBUG_COMMAND
     if (p_command->CONT) {
-        fido_log_debug("u2f_request_receive: CONT frame will receive ");
+        fido_log_debug("CONT frame will receive ");
     }
 #endif
 
@@ -375,7 +375,7 @@ static void extract_request_from_initialization_packet(uint8_t *control_point_bu
     if (p_apdu->Lc > U2F_APDU_DATA_SIZE_MAX) {
         // ヘッダーに設定されたデータ長が不正の場合、
         // ここで処理を終了
-        fido_log_error("u2f_request_receive: too long length (%d) ", p_apdu->Lc);
+        fido_log_error("apdu data Lc(%d) exceeds max buffer size(%d) ", p_apdu->Lc, U2F_APDU_DATA_SIZE_MAX);
         set_u2f_command_error(p_command, CTAP1_ERR_INVALID_LENGTH);
         return;
     }

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -60,6 +60,14 @@ static bool is_initialization_packet(uint8_t first_byte)
 
 static void u2f_request_receive_leading_packet(FIDO_COMMAND_T *p_command, FIDO_APDU_T *p_apdu)
 {
+    // 先頭データが２回連続で送信された場合はエラー
+    // （前回リクエスト受信時に設定されたCMD、CONTを参照して判定）
+    if ((p_command->CMD & 0x80) && p_command->CONT) {
+        fido_log_error("INIT frame received again while CONT is expected ");
+        set_u2f_command_error(p_command, CTAP1_ERR_INVALID_SEQ);
+        return;
+    }
+
     // コマンドとAPDUを初期化
     memset(p_command, 0, sizeof(FIDO_COMMAND_T));
     memset(p_apdu,    0, sizeof(FIDO_APDU_T));

--- a/Firmwares/fido2_lib/fido_ble_receive.c
+++ b/Firmwares/fido2_lib/fido_ble_receive.c
@@ -1,0 +1,16 @@
+/* 
+ * File:   fido_ble_receive.c
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:05
+ */
+#include <stdbool.h>
+#include <stdint.h>
+
+bool fido_ble_receive_control_point(uint8_t *data, uint16_t length)
+{
+    return false;
+}
+void fido_ble_receive_on_request_received(void)
+{
+}

--- a/Firmwares/fido2_lib/fido_ble_receive.h
+++ b/Firmwares/fido2_lib/fido_ble_receive.h
@@ -8,6 +8,7 @@
 #define FIDO_BLE_RECEIVE_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -17,7 +18,7 @@ extern "C" {
 //
 // 関数群
 //
-bool        fido_ble_receive_control_point(uint8_t *data, uint16_t length);
+bool        fido_ble_receive_control_point(uint8_t *data, size_t size);
 void        fido_ble_receive_on_request_received(void);
 
 #ifdef __cplusplus

--- a/Firmwares/fido2_lib/fido_ble_receive.h
+++ b/Firmwares/fido2_lib/fido_ble_receive.h
@@ -19,7 +19,6 @@ extern "C" {
 // 関数群
 //
 bool        fido_ble_receive_control_point(uint8_t *data, size_t size);
-void        fido_ble_receive_on_request_received(void);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_ble_receive.h
+++ b/Firmwares/fido2_lib/fido_ble_receive.h
@@ -18,7 +18,7 @@ extern "C" {
 //
 // 関数群
 //
-bool        fido_ble_receive_control_point(uint8_t *data, size_t size);
+bool        fido_ble_receive_control_point(uint8_t *data, size_t size, void *p_fido_request);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_ble_receive.h
+++ b/Firmwares/fido2_lib/fido_ble_receive.h
@@ -1,0 +1,27 @@
+/* 
+ * File:   fido_ble_receive.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:05
+ */
+#ifndef FIDO_BLE_RECEIVE_H
+#define FIDO_BLE_RECEIVE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// 関数群
+//
+bool        fido_ble_receive_control_point(uint8_t *data, uint16_t length);
+void        fido_ble_receive_on_request_received(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIDO_BLE_RECEIVE_H */

--- a/Firmwares/fido2_lib/fido_ble_send.c
+++ b/Firmwares/fido2_lib/fido_ble_send.c
@@ -4,24 +4,132 @@
  *
  * Created on 2023/05/10, 17:05
  */
+#include <string.h>
+
 #include "wrapper_common.h"
 
 #include "fido_define.h"
 #include "fido_transport_define.h"
+
+// for debug hex dump data
+#define NRF_LOG_HEXDUMP_DEBUG_PACKET        false
+
+//
+// 内部処理
+//
+// u2f_status（レスポンスバッファ）には、
+// 64バイトまで書込み可能とします
+static uint8_t  u2f_status_buffer[U2F_STATUS_SIZE_MAX];
+static uint16_t u2f_status_buffer_length;
+
+static struct {
+    // 送信済みバイト数、シーケンスを保持
+    uint32_t    size_sent;
+    uint8_t     sequence;
+
+    // 送信用BLEヘッダーに格納するコマンド、データ長、送信データを保持
+    uint8_t     cmd;
+    uint8_t    *data;
+    uint32_t    size;
+} send_info_t;
+
+static uint8_t generate_u2f_staus_header(uint8_t cmd, uint32_t length, uint8_t sequence)
+{
+    // u2f_staus_headerにおけるデータの開始位置
+    uint8_t offset;
+
+    // 領域をクリア
+    memset(u2f_status_buffer, 0, sizeof(u2f_status_buffer));
+
+    if (sequence == 0) {
+        // 先頭パケットの場合はBLEヘッダー項目を設定
+        //   コマンド
+        //   データ（APDUまたはPINGパケット）長
+        u2f_status_buffer[0] = cmd;
+        u2f_status_buffer[1] = (uint8_t)(length >> 8 & 0x000000ff);
+        u2f_status_buffer[2] = (uint8_t)(length >> 0 & 0x000000ff);
+        offset = 3;
+
+    } else {
+        // 後続パケットの場合はシーケンス番号を設定
+        u2f_status_buffer[0] = sequence - 1;
+        offset = 1;
+    }
+    return offset;
+}
+
+static uint8_t generate_u2f_staus_data(uint8_t offset)
+{
+    // 送信データ（先頭アドレス・長さ）と送信済みバイト数を取得
+    uint8_t *data_buffer = send_info_t.data;
+    uint32_t data_length = send_info_t.size;
+    uint32_t size_sent   = send_info_t.size_sent;
+
+    // 今回送信するデータ部のバイト数
+    uint32_t size_to_send;
+
+    // データの長さを計算
+    // (総バイト数 - 送信ずみバイト数)
+    uint32_t remaining = data_length - size_sent;
+
+    // 今回送信するデータ部のバイト数を計算
+    u2f_status_buffer_length = remaining + offset;
+    if (u2f_status_buffer_length > U2F_STATUS_SIZE_MAX) {
+        u2f_status_buffer_length = U2F_STATUS_SIZE_MAX;
+    }
+    size_to_send = u2f_status_buffer_length - offset;
+
+    // データ部をセット
+    memcpy(u2f_status_buffer + offset, data_buffer + size_sent, size_to_send);
+    return size_to_send;
+}
+
+static void ble_u2f_status_response_send(void)
+{
+    // ヘッダー項目、データ部を編集
+    uint8_t  offset = generate_u2f_staus_header(send_info_t.cmd, send_info_t.size, send_info_t.sequence);
+    uint32_t length = generate_u2f_staus_data(offset);
+
+    // u2f_status_bufferに格納されたパケットを送信
+    if (fido_ble_response_send(u2f_status_buffer, u2f_status_buffer_length)) {
+        // 送信済みバイト数、シーケンスを更新
+        send_info_t.size_sent += length;
+        send_info_t.sequence++;
+    }
+}
 
 //
 // 公開用関数
 //
 void fido_ble_send_response(void *p_fido_response)
 {
-    // TODO: 仮の実装です。
+    // 送信情報を初期化
+    memset(&send_info_t, 0, sizeof(send_info_t));
+
+    // 送信のために必要な情報を保持
     FIDO_RESPONSE_T *p_response = p_fido_response;
-    fido_log_debug("U2F response: CMD=0x%02x (%d bytes):", p_response->cmd, p_response->size);
+    send_info_t.cmd  = p_response->cmd;
+    send_info_t.data = p_response->data;
+    send_info_t.size = p_response->size;
+
+#if NRF_LOG_HEXDUMP_DEBUG_PACKET
+    fido_log_debug("U2F status to send: CMD=0x%02x (%d bytes):", p_response->cmd, p_response->size);
     fido_log_print_hexdump_debug(p_response->data, p_response->size);
+#endif
+
+    // 先頭フレームの送信を実行
+    ble_u2f_status_response_send();
 }
 
 bool fido_ble_send_response_done(void)
 {
-    // TODO: 仮の実装です。
-    return false;
+    // 最終レコードの場合
+    if (send_info_t.size_sent == send_info_t.size) {
+        // FIDOレスポンス送信完了時の処理を実行
+        return true;
+    } else {
+        // 後続フレームの送信を実行
+        ble_u2f_status_response_send();
+        return false;
+    }
 }

--- a/Firmwares/fido2_lib/fido_ble_send.c
+++ b/Firmwares/fido2_lib/fido_ble_send.c
@@ -1,0 +1,10 @@
+/* 
+ * File:   fido_ble_send.c
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:05
+ */
+
+void fido_ble_send_on_tx_complete(void)
+{
+}

--- a/Firmwares/fido2_lib/fido_ble_send.c
+++ b/Firmwares/fido2_lib/fido_ble_send.c
@@ -9,10 +9,19 @@
 #include "fido_define.h"
 #include "fido_transport_define.h"
 
+//
+// 公開用関数
+//
 void fido_ble_send_response(void *p_fido_response)
 {
     // TODO: 仮の実装です。
     FIDO_RESPONSE_T *p_response = p_fido_response;
     fido_log_debug("U2F response: CMD=0x%02x (%d bytes):", p_response->cmd, p_response->size);
     fido_log_print_hexdump_debug(p_response->data, p_response->size);
+}
+
+bool fido_ble_send_response_done(void)
+{
+    // TODO: 仮の実装です。
+    return false;
 }

--- a/Firmwares/fido2_lib/fido_ble_send.c
+++ b/Firmwares/fido2_lib/fido_ble_send.c
@@ -4,7 +4,15 @@
  *
  * Created on 2023/05/10, 17:05
  */
+#include "wrapper_common.h"
 
-void fido_ble_send_on_tx_complete(void)
+#include "fido_define.h"
+#include "fido_transport_define.h"
+
+void fido_ble_send_response(void *p_fido_response)
 {
+    // TODO: 仮の実装です。
+    FIDO_RESPONSE_T *p_response = p_fido_response;
+    fido_log_debug("U2F response: CMD=0x%02x (%d bytes):", p_response->cmd, p_response->size);
+    fido_log_print_hexdump_debug(p_response->data, p_response->size);
 }

--- a/Firmwares/fido2_lib/fido_ble_send.h
+++ b/Firmwares/fido2_lib/fido_ble_send.h
@@ -1,0 +1,23 @@
+/* 
+ * File:   fido_ble_send.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:05
+ */
+#ifndef FIDO_BLE_SEND_H
+#define FIDO_BLE_SEND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// 関数群
+//
+void        fido_ble_send_on_tx_complete(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIDO_BLE_SEND_H */

--- a/Firmwares/fido2_lib/fido_ble_send.h
+++ b/Firmwares/fido2_lib/fido_ble_send.h
@@ -7,6 +7,8 @@
 #ifndef FIDO_BLE_SEND_H
 #define FIDO_BLE_SEND_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,6 +17,7 @@ extern "C" {
 // 関数群
 //
 void        fido_ble_send_response(void *p_fido_response);
+bool        fido_ble_send_response_done(void);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_ble_send.h
+++ b/Firmwares/fido2_lib/fido_ble_send.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // 関数群
 //
-void        fido_ble_send_on_tx_complete(void);
+void        fido_ble_send_response(void *p_fido_response);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_command.c
+++ b/Firmwares/fido2_lib/fido_command.c
@@ -33,6 +33,11 @@ static void fido_u2f_command_ping(FIDO_REQUEST_T *p_fido_request, FIDO_RESPONSE_
     memcpy(p_fido_response->data, p_apdu->data, p_apdu->data_length);
 }
 
+static void fido_u2f_command_ping_done(void)
+{
+    fido_log_info("U2F ping end");
+}
+
 void fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_response)
 {
     // データ受信後に実行すべき処理を判定
@@ -40,6 +45,18 @@ void fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_res
         case U2F_COMMAND_PING:
             // PINGレスポンスを実行
             fido_u2f_command_ping(p_fido_request, p_fido_response);
+            break;
+        default:
+            break;
+    }
+}
+
+void fido_command_on_ble_response_sent(void *p_fido_request, void *p_fido_response)
+{
+    // レスポンス送信完了後に実行すべき処理を判定
+    switch (u2f_command_byte(p_fido_request)) {
+        case U2F_COMMAND_PING:
+            fido_u2f_command_ping_done();
             break;
         default:
             break;

--- a/Firmwares/fido2_lib/fido_command.c
+++ b/Firmwares/fido2_lib/fido_command.c
@@ -1,0 +1,40 @@
+/* 
+ * File:   fido_command.c
+ * Author: makmorit
+ *
+ * Created on 2023/05/12, 10:51
+ */
+#include "wrapper_common.h"
+
+#include "fido_define.h"
+#include "fido_transport_define.h"
+
+//
+// 内部処理
+//
+static uint8_t u2f_command_byte(FIDO_REQUEST_T *p_fido_request)
+{
+    FIDO_COMMAND_T *p_command = &p_fido_request->command;
+    return p_command->CMD & 0x7f;
+}
+
+static void fido_u2f_command_ping(FIDO_REQUEST_T *p_fido_request)
+{
+    // TODO: 仮の実装です。
+    FIDO_APDU_T *p_apdu = &p_fido_request->apdu;
+    fido_log_debug("U2F Ping start (%d bytes):", p_apdu->data_length);
+    fido_log_print_hexdump_debug(p_apdu->data, p_apdu->data_length);
+}
+
+void fido_command_on_ble_request_receive_completed(void *p_fido_request)
+{
+    // データ受信後に実行すべき処理を判定
+    switch (u2f_command_byte(p_fido_request)) {
+        case U2F_COMMAND_PING:
+            // PINGレスポンスを実行
+            fido_u2f_command_ping(p_fido_request);
+            break;
+        default:
+            break;
+    }
+}

--- a/Firmwares/fido2_lib/fido_command.c
+++ b/Firmwares/fido2_lib/fido_command.c
@@ -4,6 +4,8 @@
  *
  * Created on 2023/05/12, 10:51
  */
+#include <string.h>
+
 #include "wrapper_common.h"
 
 #include "fido_define.h"
@@ -38,6 +40,17 @@ static void fido_u2f_command_ping_done(void)
     fido_log_info("U2F ping end");
 }
 
+static void fido_u2f_command_error(FIDO_REQUEST_T *p_fido_request, FIDO_RESPONSE_T *p_fido_response)
+{
+    // エラーレスポンスを生成
+    FIDO_COMMAND_T *p_command = &p_fido_request->command;
+
+    p_fido_response->cid     = p_command->CID;
+    p_fido_response->cmd     = p_command->CMD;
+    p_fido_response->size    = 1;
+    p_fido_response->data[0] = p_command->ERROR;
+}
+
 void fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_response)
 {
     // データ受信後に実行すべき処理を判定
@@ -45,6 +58,10 @@ void fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_res
         case U2F_COMMAND_PING:
             // PINGレスポンスを実行
             fido_u2f_command_ping(p_fido_request, p_fido_response);
+            break;
+        case U2F_COMMAND_ERROR:
+            // エラーレスポンスを実行
+            fido_u2f_command_error(p_fido_request, p_fido_response);
             break;
         default:
             break;

--- a/Firmwares/fido2_lib/fido_command.c
+++ b/Firmwares/fido2_lib/fido_command.c
@@ -18,23 +18,28 @@ static uint8_t u2f_command_byte(FIDO_REQUEST_T *p_fido_request)
     return p_command->CMD & 0x7f;
 }
 
-static void fido_u2f_command_ping(FIDO_REQUEST_T *p_fido_request)
+static void fido_u2f_command_ping(FIDO_REQUEST_T *p_fido_request, FIDO_RESPONSE_T *p_fido_response)
 {
     fido_log_info("U2F ping start");
 
-    // TODO: 仮の実装です。
-    FIDO_APDU_T *p_apdu = &p_fido_request->apdu;
-    fido_log_debug("U2F Ping start (%d bytes):", p_apdu->data_length);
-    fido_log_print_hexdump_debug(p_apdu->data, p_apdu->data_length);
+    // リクエストのヘッダーとデータを編集せず
+    // レスポンスとして戻す（エコーバック）
+    FIDO_APDU_T    *p_apdu    = &p_fido_request->apdu;
+    FIDO_COMMAND_T *p_command = &p_fido_request->command;
+
+    p_fido_response->cid  = p_command->CID;
+    p_fido_response->cmd  = p_command->CMD;
+    p_fido_response->size = p_apdu->data_length;
+    memcpy(p_fido_response->data, p_apdu->data, p_apdu->data_length);
 }
 
-void fido_command_on_ble_request_receive_completed(void *p_fido_request)
+void fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_response)
 {
     // データ受信後に実行すべき処理を判定
     switch (u2f_command_byte(p_fido_request)) {
         case U2F_COMMAND_PING:
             // PINGレスポンスを実行
-            fido_u2f_command_ping(p_fido_request);
+            fido_u2f_command_ping(p_fido_request, p_fido_response);
             break;
         default:
             break;

--- a/Firmwares/fido2_lib/fido_command.c
+++ b/Firmwares/fido2_lib/fido_command.c
@@ -20,6 +20,8 @@ static uint8_t u2f_command_byte(FIDO_REQUEST_T *p_fido_request)
 
 static void fido_u2f_command_ping(FIDO_REQUEST_T *p_fido_request)
 {
+    fido_log_info("U2F ping start");
+
     // TODO: 仮の実装です。
     FIDO_APDU_T *p_apdu = &p_fido_request->apdu;
     fido_log_debug("U2F Ping start (%d bytes):", p_apdu->data_length);

--- a/Firmwares/fido2_lib/fido_command.h
+++ b/Firmwares/fido2_lib/fido_command.h
@@ -1,0 +1,23 @@
+/* 
+ * File:   fido_command.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/12, 10:51
+ */
+#ifndef FIDO_COMMAND_H
+#define FIDO_COMMAND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// 関数群
+//
+void        fido_command_on_ble_request_receive_completed(void *p_fido_request);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIDO_COMMAND_H */

--- a/Firmwares/fido2_lib/fido_command.h
+++ b/Firmwares/fido2_lib/fido_command.h
@@ -14,7 +14,7 @@ extern "C" {
 //
 // 関数群
 //
-void        fido_command_on_ble_request_receive_completed(void *p_fido_request);
+void        fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_response);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_command.h
+++ b/Firmwares/fido2_lib/fido_command.h
@@ -15,6 +15,7 @@ extern "C" {
 // 関数群
 //
 void        fido_command_on_ble_request_received(void *p_fido_request, void *p_fido_response);
+void        fido_command_on_ble_response_sent(void *p_fido_request, void *p_fido_response);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_define.h
+++ b/Firmwares/fido2_lib/fido_define.h
@@ -58,6 +58,9 @@ extern "C" {
 #define U2F_COMMAND_CANCEL                  0x3e
 #define U2F_COMMAND_ERROR                   0x3f
 
+// U2Fトランスポート関連
+#define U2F_CONTROL_POINT_SIZE_MAX          64
+
 #ifdef __cplusplus
 }
 #endif

--- a/Firmwares/fido2_lib/fido_define.h
+++ b/Firmwares/fido2_lib/fido_define.h
@@ -51,15 +51,21 @@ extern "C" {
 #define CTAP2_ERR_VENDOR_FIRST              0xf0
 #define CTAP2_ERR_VENDOR_LAST               0xff
 
+// Command status responses
+#define U2F_SW_NO_ERROR                     0x9000
+#define U2F_SW_WRONG_DATA                   0x6A80
+#define U2F_SW_CONDITIONS_NOT_SATISFIED     0x6985
+#define U2F_SW_COMMAND_NOT_ALLOWED          0x6986
+#define U2F_SW_INS_NOT_SUPPORTED            0x6D00
+#define U2F_SW_WRONG_LENGTH                 0x6700
+#define U2F_SW_CLA_NOT_SUPPORTED            0x6E00
+
 // U2Fコマンドの識別用
 #define U2F_COMMAND_PING                    0x01
 #define U2F_COMMAND_KEEPALIVE               0x02
 #define U2F_COMMAND_MSG                     0x03
 #define U2F_COMMAND_CANCEL                  0x3e
 #define U2F_COMMAND_ERROR                   0x3f
-
-// U2Fトランスポート関連
-#define U2F_CONTROL_POINT_SIZE_MAX          64
 
 #ifdef __cplusplus
 }

--- a/Firmwares/fido2_lib/fido_define.h
+++ b/Firmwares/fido2_lib/fido_define.h
@@ -1,0 +1,61 @@
+/* 
+ * File:   fido_define.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/11, 10:26
+ */
+#ifndef FIDO_DEFINE_H
+#define FIDO_DEFINE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// FIDO関連 バージョン文字列
+#define U2F_V2_VERSION_STRING               "U2F_V2"
+#define FIDO_2_0_VERSION_STRING             "FIDO_2_0"
+
+// FIDO機能関連エラーステータス
+#define CTAP1_ERR_SUCCESS                   0x00
+#define CTAP1_ERR_INVALID_COMMAND           0x01
+#define CTAP1_ERR_INVALID_PARAMETER         0x02
+#define CTAP1_ERR_INVALID_LENGTH            0x03
+#define CTAP1_ERR_INVALID_SEQ               0x04
+#define CTAP1_ERR_TIMEOUT                   0x05
+#define CTAP1_ERR_CHANNEL_BUSY              0x06
+#define CTAP1_ERR_LOCK_REQUIRED             0x0a
+#define CTAP1_ERR_INVALID_CHANNEL           0x0b
+#define CTAP2_ERR_CBOR_PARSING              0x10
+#define CTAP2_ERR_CBOR_UNEXPECTED_TYPE      0x11
+#define CTAP2_ERR_INVALID_CBOR              0x12
+#define CTAP2_ERR_INVALID_CBOR_TYPE         0x13
+#define CTAP2_ERR_MISSING_PARAMETER         0x14
+#define CTAP2_ERR_LIMIT_EXCEEDED            0x15
+#define CTAP2_ERR_TOO_MANY_ELEMENTS         0x17
+#define CTAP2_ERR_CREDENTIAL_EXCLUDED       0x19
+#define CTAP2_ERR_PROCESSING                0x21
+#define CTAP2_ERR_UNSUPPORTED_ALGORITHM     0x26
+#define CTAP2_ERR_INVALID_OPTION            0x2c
+#define CTAP2_ERR_KEEPALIVE_CANCEL          0x2d
+#define CTAP2_ERR_NO_CREDENTIALS            0x2e
+#define CTAP2_ERR_PIN_INVALID               0x31
+#define CTAP2_ERR_PIN_BLOCKED               0x32
+#define CTAP2_ERR_PIN_AUTH_INVALID          0x33
+#define CTAP2_ERR_PIN_AUTH_BLOCKED          0x34
+#define CTAP2_ERR_PIN_NOT_SET               0x35
+#define CTAP2_ERR_PIN_POLICY_VIOLATION      0x37
+#define CTAP1_ERR_OTHER                     0x7f
+#define CTAP2_ERR_SPEC_LAST                 0xdf
+#define CTAP2_ERR_EXTENSION_FIRST           0xe0
+#define CTAP2_ERR_EXTENSION_LAST            0xef
+#define CTAP2_ERR_VENDOR_FIRST              0xf0
+#define CTAP2_ERR_VENDOR_LAST               0xff
+
+// U2Fコマンドの識別用
+#define U2F_COMMAND_ERROR                   0x3f
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIDO_DEFINE_H */

--- a/Firmwares/fido2_lib/fido_define.h
+++ b/Firmwares/fido2_lib/fido_define.h
@@ -52,6 +52,10 @@ extern "C" {
 #define CTAP2_ERR_VENDOR_LAST               0xff
 
 // U2Fコマンドの識別用
+#define U2F_COMMAND_PING                    0x01
+#define U2F_COMMAND_KEEPALIVE               0x02
+#define U2F_COMMAND_MSG                     0x03
+#define U2F_COMMAND_CANCEL                  0x3e
 #define U2F_COMMAND_ERROR                   0x3f
 
 #ifdef __cplusplus

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -41,6 +41,7 @@ typedef struct {
     uint8_t *data;
     uint32_t data_length;
     uint32_t Le;
+    uint8_t  ctap2_command;
 } FIDO_APDU_T;
 
 #ifdef __cplusplus

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -48,6 +48,12 @@ typedef struct {
     uint8_t  ctap2_command;
 } FIDO_APDU_T;
 
+// リクエストデータを集約
+typedef struct {
+    FIDO_COMMAND_T command;
+    FIDO_APDU_T    apdu;
+} FIDO_REQUEST_T;
+
 #ifdef __cplusplus
 }
 #endif

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -16,6 +16,7 @@ extern "C" {
 
 // U2Fトランスポート関連
 #define U2F_CONTROL_POINT_SIZE_MAX          64
+#define U2F_STATUS_SIZE_MAX                 64
 #define U2F_APDU_DATA_SIZE_MAX              1024
 
 // リクエストデータに含まれるコマンドヘッダーを保持

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -54,6 +54,15 @@ typedef struct {
     FIDO_APDU_T    apdu;
 } FIDO_REQUEST_T;
 
+// レスポンスデータを集約
+typedef struct {
+    uint32_t cid;
+    uint8_t  cmd;
+    uint8_t  data[U2F_APDU_DATA_SIZE_MAX];
+    uint32_t size;
+    uint16_t sw;
+} FIDO_RESPONSE_T;
+
 #ifdef __cplusplus
 }
 #endif

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -44,6 +44,10 @@ typedef struct {
     uint8_t  ctap2_command;
 } FIDO_APDU_T;
 
+// U2Fトランスポート関連
+#define U2F_CONTROL_POINT_SIZE_MAX          64
+#define U2F_APDU_DATA_SIZE_MAX              1024
+
 #ifdef __cplusplus
 }
 #endif

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -1,0 +1,50 @@
+/* 
+ * File:   fido_transport_define.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/11, 10:19
+ */
+#ifndef FIDO_TRANSPORT_DEFINE_H
+#define FIDO_TRANSPORT_DEFINE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// リクエストデータに含まれるコマンドヘッダーを保持
+typedef struct {
+    uint32_t CID;
+    uint8_t  CMD;
+    uint32_t LEN;
+    uint8_t  SEQ;
+
+    // リクエストデータの検査中に確認されたエラーを保持
+    uint8_t  ERROR;
+
+    // リクエストデータの検査中に設定されたステータスワードを保持
+    uint16_t STATUS_WORD;
+
+    // 後続リクエストがあるかどうかを保持
+    bool CONT;
+} FIDO_COMMAND_T;
+
+// リクエストデータに含まれるAPDU項目を保持
+typedef struct {
+    uint8_t  CLA;
+    uint8_t  INS;
+    uint8_t  P1;
+    uint8_t  P2;
+    uint32_t Lc;
+    uint8_t *data;
+    uint32_t data_length;
+    uint32_t Le;
+} FIDO_APDU_T;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIDO_TRANSPORT_DEFINE_H */

--- a/Firmwares/fido2_lib/fido_transport_define.h
+++ b/Firmwares/fido2_lib/fido_transport_define.h
@@ -14,6 +14,10 @@
 extern "C" {
 #endif
 
+// U2Fトランスポート関連
+#define U2F_CONTROL_POINT_SIZE_MAX          64
+#define U2F_APDU_DATA_SIZE_MAX              1024
+
 // リクエストデータに含まれるコマンドヘッダーを保持
 typedef struct {
     uint32_t CID;
@@ -38,15 +42,11 @@ typedef struct {
     uint8_t  P1;
     uint8_t  P2;
     uint32_t Lc;
-    uint8_t *data;
+    uint8_t  data[U2F_APDU_DATA_SIZE_MAX];
     uint32_t data_length;
     uint32_t Le;
     uint8_t  ctap2_command;
 } FIDO_APDU_T;
-
-// U2Fトランスポート関連
-#define U2F_CONTROL_POINT_SIZE_MAX          64
-#define U2F_APDU_DATA_SIZE_MAX              1024
 
 #ifdef __cplusplus
 }

--- a/Firmwares/wrapper_header/wrapper_common.h
+++ b/Firmwares/wrapper_header/wrapper_common.h
@@ -17,6 +17,7 @@ extern "C" {
 //
 // 関数群
 //
+void        fido_log_error(const char *fmt, ...);
 void        fido_log_debug(const char *fmt, ...);
 void        fido_log_print_hexdump_debug(uint8_t *data, size_t size);
 

--- a/Firmwares/wrapper_header/wrapper_common.h
+++ b/Firmwares/wrapper_header/wrapper_common.h
@@ -1,0 +1,27 @@
+/* 
+ * File:   wrapper_common.h
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:22
+ */
+#ifndef WRAPPER_COMMON_H
+#define WRAPPER_COMMON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// 関数群
+//
+void        fido_log_debug(const char *fmt, ...);
+void        fido_log_print_hexdump_debug(uint8_t *data, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WRAPPER_COMMON_H */

--- a/Firmwares/wrapper_header/wrapper_common.h
+++ b/Firmwares/wrapper_header/wrapper_common.h
@@ -7,6 +7,7 @@
 #ifndef WRAPPER_COMMON_H
 #define WRAPPER_COMMON_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -21,6 +22,7 @@ void        fido_log_error(const char *fmt, ...);
 void        fido_log_info(const char *fmt, ...);
 void        fido_log_debug(const char *fmt, ...);
 void        fido_log_print_hexdump_debug(uint8_t *data, size_t size);
+bool        fido_ble_response_send(uint8_t *u2f_status_buffer, size_t u2f_status_buffer_length);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/wrapper_header/wrapper_common.h
+++ b/Firmwares/wrapper_header/wrapper_common.h
@@ -18,6 +18,7 @@ extern "C" {
 // 関数群
 //
 void        fido_log_error(const char *fmt, ...);
+void        fido_log_info(const char *fmt, ...);
 void        fido_log_debug(const char *fmt, ...);
 void        fido_log_print_hexdump_debug(uint8_t *data, size_t size);
 

--- a/nRF5340FW/square_devices_app/CMakeLists.txt
+++ b/nRF5340FW/square_devices_app/CMakeLists.txt
@@ -19,4 +19,5 @@ target_include_directories(app PRIVATE
     $ENV{ZEPHYR_BASE}/subsys/settings/include
     app
     $ENV{FWLIB_PATH}/fido2_lib
+    $ENV{FWLIB_PATH}/wrapper_header
 )

--- a/nRF5340FW/square_devices_app/CMakeLists.txt
+++ b/nRF5340FW/square_devices_app/CMakeLists.txt
@@ -11,9 +11,12 @@ target_sources(app PRIVATE
     ${app_sources}
     ${wrapper_sources}
     $ENV{NCS_HOME}/mbedtls/library/ctr_drbg.c
+    $ENV{FWLIB_PATH}/fido2_lib/fido_ble_receive.c
+    $ENV{FWLIB_PATH}/fido2_lib/fido_ble_send.c
 )
 target_include_directories(app PRIVATE 
     $ENV{NCS_HOME}/modules/lib/tinycbor/include
     $ENV{ZEPHYR_BASE}/subsys/settings/include
     app
+    $ENV{FWLIB_PATH}/fido2_lib
 )

--- a/nRF5340FW/square_devices_app/CMakeLists.txt
+++ b/nRF5340FW/square_devices_app/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(app PRIVATE
     $ENV{NCS_HOME}/mbedtls/library/ctr_drbg.c
     $ENV{FWLIB_PATH}/fido2_lib/fido_ble_receive.c
     $ENV{FWLIB_PATH}/fido2_lib/fido_ble_send.c
+    $ENV{FWLIB_PATH}/fido2_lib/fido_command.c
 )
 target_include_directories(app PRIVATE 
     $ENV{NCS_HOME}/modules/lib/tinycbor/include

--- a/nRF5340FW/square_devices_app/prj.conf
+++ b/nRF5340FW/square_devices_app/prj.conf
@@ -1,7 +1,7 @@
 #
 # for firmware revision control
 #
-CONFIG_APP_FW_BUILD=101
+CONFIG_APP_FW_BUILD=102
 
 #
 # for Bluetooth peripheral

--- a/nRF5340FW/square_devices_app/westbuild.sh
+++ b/nRF5340FW/square_devices_app/westbuild.sh
@@ -11,6 +11,9 @@ export GNUARMEMB_TOOLCHAIN_PATH="${HOME}/opt/arm-gnu-toolchain-12.2.rel1-darwin-
 # Paths for command
 export PATH=${PATH}:/usr/local/bin
 
+# Paths for firmware source & header
+export FWLIB_PATH=../../Firmwares
+
 # bash completion
 export NCS_HOME=${HOME}/opt/ncs_2.2.0
 export ZEPHYR_BASE=${NCS_HOME}/zephyr

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -117,7 +117,9 @@ void wrapper_main_ble_request_received(void)
 
 void wrapper_main_ble_response_sent(void)
 {
-    // TODO: 各種業務処理を実行
+    if (fido_ble_send_response_done()) {
+        fido_command_on_ble_response_sent(&m_fido_request, &m_fido_response);
+    }
 }
 
 void wrapper_main_ble_nus_data_frame_received(uint8_t *data, size_t size)

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -12,6 +12,10 @@
 //
 #include "fido_ble_receive.h"
 #include "fido_ble_send.h"
+#include "fido_transport_define.h"
+
+// 業務リクエスト／レスポンスデータを保持
+static FIDO_REQUEST_T m_fido_request;
 
 //
 // 業務処理-->プラットフォーム連携用
@@ -96,7 +100,7 @@ void wrapper_main_ccid_request_received(void)
 
 void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 {
-    if (fido_ble_receive_control_point(data, size)) {
+    if (fido_ble_receive_control_point(data, size, &m_fido_request)) {
         // メインスレッドを経由し、
         // wrapper_main_ble_request_received を実行させる
         app_main_event_notify_ble_request_received();

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -105,7 +105,7 @@ void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 
 void wrapper_main_ble_request_received(void)
 {
-    fido_ble_receive_on_request_received();
+    // TODO: 各種業務処理を実行
 }
 
 void wrapper_main_ble_response_sent(void)

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -12,6 +12,7 @@
 //
 #include "fido_ble_receive.h"
 #include "fido_ble_send.h"
+#include "fido_command.h"
 #include "fido_transport_define.h"
 
 // 業務リクエスト／レスポンスデータを保持
@@ -109,7 +110,7 @@ void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 
 void wrapper_main_ble_request_received(void)
 {
-    // TODO: 各種業務処理を実行
+    fido_command_on_ble_request_receive_completed(&m_fido_request);
 }
 
 void wrapper_main_ble_response_sent(void)

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -112,6 +112,7 @@ void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 void wrapper_main_ble_request_received(void)
 {
     fido_command_on_ble_request_received(&m_fido_request, &m_fido_response);
+    fido_ble_send_response(&m_fido_response);
 }
 
 void wrapper_main_ble_response_sent(void)

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -16,7 +16,8 @@
 #include "fido_transport_define.h"
 
 // 業務リクエスト／レスポンスデータを保持
-static FIDO_REQUEST_T m_fido_request;
+static FIDO_REQUEST_T  m_fido_request;
+static FIDO_RESPONSE_T m_fido_response;
 
 //
 // 業務処理-->プラットフォーム連携用
@@ -110,12 +111,12 @@ void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 
 void wrapper_main_ble_request_received(void)
 {
-    fido_command_on_ble_request_receive_completed(&m_fido_request);
+    fido_command_on_ble_request_received(&m_fido_request, &m_fido_response);
 }
 
 void wrapper_main_ble_response_sent(void)
 {
-    fido_ble_send_on_tx_complete();
+    // TODO: 各種業務処理を実行
 }
 
 void wrapper_main_ble_nus_data_frame_received(uint8_t *data, size_t size)

--- a/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrapper_main.c
@@ -10,6 +10,8 @@
 //
 // TODO: 業務処理関連のヘッダーをインクルード
 //
+#include "fido_ble_receive.h"
+#include "fido_ble_send.h"
 
 //
 // 業務処理-->プラットフォーム連携用
@@ -94,17 +96,21 @@ void wrapper_main_ccid_request_received(void)
 
 void wrapper_main_ble_data_frame_received(uint8_t *data, size_t size)
 {
-    // TODO: 各種業務処理を実行
+    if (fido_ble_receive_control_point(data, size)) {
+        // メインスレッドを経由し、
+        // wrapper_main_ble_request_received を実行させる
+        app_main_event_notify_ble_request_received();
+    }
 }
 
 void wrapper_main_ble_request_received(void)
 {
-    // TODO: 各種業務処理を実行
+    fido_ble_receive_on_request_received();
 }
 
 void wrapper_main_ble_response_sent(void)
 {
-    // TODO: 各種業務処理を実行
+    fido_ble_send_on_tx_complete();
 }
 
 void wrapper_main_ble_nus_data_frame_received(uint8_t *data, size_t size)

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -1,0 +1,36 @@
+/* 
+ * File:   wrapper_common.c
+ * Author: makmorit
+ *
+ * Created on 2023/05/10, 17:22
+ */
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+
+#include <stdio.h>
+
+// メッセージを保持
+static char message_buff[1024];
+
+void fido_log_debug(const char *fmt, ...)
+{
+    // メッセージをフォーマット
+    va_list ap;
+    va_start(ap, fmt);
+    vsprintf(message_buff, fmt, ap);
+    va_end(ap);
+
+    // メッセージを出力
+    printk("%s\n", message_buff);
+}
+
+void fido_log_print_hexdump_debug(uint8_t *data, size_t size)
+{
+    for (int i = 0; i < size; i++) {
+        printk("%02x ", data[i]);
+        if ((i % 16 == 15) && (i < size - 1)) {
+            printk("\n");
+        }
+    }
+    printk("\n");
+}

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -25,7 +25,7 @@ void fido_log_error(const char *fmt, ...)
     va_end(ap);
 
     // メッセージをZephyrログに出力
-    LOG_ERR("%s\n", message_buff);
+    LOG_ERR("%s", message_buff);
 }
 
 void fido_log_debug(const char *fmt, ...)

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -62,3 +62,13 @@ void fido_log_print_hexdump_debug(uint8_t *data, size_t size)
     }
     printk("\n");
 }
+
+//
+// トランスポート関連
+//
+#include "app_ble_fido.h"
+
+bool fido_ble_response_send(uint8_t *u2f_status_buffer, size_t u2f_status_buffer_length)
+{
+    return app_ble_fido_send_data(u2f_status_buffer, u2f_status_buffer_length);
+}

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -28,6 +28,18 @@ void fido_log_error(const char *fmt, ...)
     LOG_ERR("%s", message_buff);
 }
 
+void fido_log_info(const char *fmt, ...)
+{
+    // メッセージをフォーマット
+    va_list ap;
+    va_start(ap, fmt);
+    vsprintf(message_buff, fmt, ap);
+    va_end(ap);
+
+    // メッセージをZephyrログに出力
+    LOG_INF("%s", message_buff);
+}
+
 void fido_log_debug(const char *fmt, ...)
 {
     // メッセージをフォーマット

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -9,8 +9,24 @@
 
 #include <stdio.h>
 
+#define LOG_LEVEL LOG_LEVEL_DBG
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(app);
+
 // メッセージを保持
 static char message_buff[1024];
+
+void fido_log_error(const char *fmt, ...)
+{
+    // メッセージをフォーマット
+    va_list ap;
+    va_start(ap, fmt);
+    vsprintf(message_buff, fmt, ap);
+    va_end(ap);
+
+    // メッセージをZephyrログに出力
+    LOG_ERR("%s\n", message_buff);
+}
 
 void fido_log_debug(const char *fmt, ...)
 {


### PR DESCRIPTION
## 概要
nRF5340基板のファームウェアに対し、FIDO 2.0のBLEトランスポート仕様に則ったコマンドを投入／実行できるようにします。

本プルリクエストでは、最低限、PING (`0x01`)コマンドの実行ができるようになる事を目標とします。
具体的には、セントラルからの送信データと同じ内容を、nRF5340側からレスポンスとして戻します。
（BLEセントラルとnRF5340の疎通確認で使用します）

### 参考資料
FIDO 2.0 BLEトランスポートについての資料
https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ble
