### PR TITLE
[ファーム対応] ペアリング機能の実装

### DIFF
--- a/nRF5340FW/square_devices_app/prj.conf
+++ b/nRF5340FW/square_devices_app/prj.conf
@@ -1,7 +1,7 @@
 #
 # for firmware revision control
 #
-CONFIG_APP_FW_BUILD=102
+CONFIG_APP_FW_BUILD=103
 
 #
 # for Bluetooth peripheral


### PR DESCRIPTION
## 概要
現在制作中の[デスクトップツール](https://github.com/makmorit/SquareDevices/tree/main/DesktopTools)から、ペアリング要求／ペアリング解除要求に応じることが出来るよう、ペアリング機能をnRF5340ファームウェアに実装します。

#### ペアリング要求
BLEセントラルからペアリング要求があった場合、パスコード（６桁の数字）をセントラル側に要求します。
（パスコードは、nRF5340基板側で表示します）
パスコードが入力されたら、ペアリング情報をnRF5340に保存してペアリングを成立させます。

#### ペアリング解除要求
BLEセントラルから、ペアリング解除要求コマンドが送信された場合、接続中のペアリング情報をnRF5340側で削除します。
ペアリング解除要求は、#7 で開通させたFIDO BLEトランスポートを使用して行う想定です。

#### ペアリングモードとの関連
ペアリング要求は、nRF5340側がペアリングモードでないと実行できないものとします。
また、ペアリング解除要求は、nRF5340側がペアリングモードの場合、実行できないものとします。