### PR TITLE
[ファーム対応] 時刻同期機能の実装

### DIFF
--- a/Firmwares/fw_common/fw_common.c
+++ b/Firmwares/fw_common/fw_common.c
@@ -24,3 +24,16 @@ uint16_t fw_common_get_uint16_from_bytes(uint8_t *p_src_buffer)
     p_dest_buffer[1] = p_src_buffer[0];
     return uint16;
 }
+
+uint32_t fw_common_get_uint32_from_bytes(uint8_t *p_src_buffer)
+{
+    // ４バイトのビッグエンディアン形式配列を、
+    // ４バイト整数に変換
+    uint32_t uint32;
+    uint8_t *p_dest_buffer = (uint8_t *)&uint32;
+    p_dest_buffer[0] = p_src_buffer[3];
+    p_dest_buffer[1] = p_src_buffer[2];
+    p_dest_buffer[2] = p_src_buffer[1];
+    p_dest_buffer[3] = p_src_buffer[0];
+    return uint32;
+}

--- a/Firmwares/fw_common/fw_common.h
+++ b/Firmwares/fw_common/fw_common.h
@@ -18,6 +18,7 @@ extern "C" {
 //
 void        fw_common_set_uint16_bytes(uint8_t *p_dest_buffer, uint16_t bytes);
 uint16_t    fw_common_get_uint16_from_bytes(uint8_t *p_src_buffer);
+uint32_t    fw_common_get_uint32_from_bytes(uint8_t *p_src_buffer);
 
 #ifdef __cplusplus
 }

--- a/Firmwares/vendor_lib/vendor_command.c
+++ b/Firmwares/vendor_lib/vendor_command.c
@@ -105,6 +105,9 @@ void vendor_command_on_fido_msg(void *fido_request, void *fido_response)
     // TODO: 仮の実装です。
     uint8_t ctap2_command = p_apdu->ctap2_command;
     switch (ctap2_command) {
+        case VENDOR_COMMAND_GET_TIMESTAMP:
+        case VENDOR_COMMAND_SET_TIMESTAMP:
+            break;
         case VENDOR_COMMAND_UNPAIRING_REQUEST:
         case VENDOR_COMMAND_ERASE_BONDING_DATA:
             command_unpairing_request(p_fido_request, p_fido_response);

--- a/Firmwares/vendor_lib/vendor_command_define.h
+++ b/Firmwares/vendor_lib/vendor_command_define.h
@@ -12,6 +12,8 @@ extern "C" {
 #endif
 
 // ベンダー固有コマンドの識別用
+#define VENDOR_COMMAND_GET_TIMESTAMP        0x4a
+#define VENDOR_COMMAND_SET_TIMESTAMP        0x4b
 #define VENDOR_COMMAND_UNPAIRING_REQUEST    0x4d
 #define VENDOR_COMMAND_UNPAIRING_CANCEL     0x4e
 #define VENDOR_COMMAND_ERASE_BONDING_DATA   0x4f

--- a/Firmwares/wrapper_header/wrapper_common.h
+++ b/Firmwares/wrapper_header/wrapper_common.h
@@ -27,6 +27,8 @@ void        fido_ble_peripheral_terminate(void);
 bool        fido_ble_unpairing_get_peer_id(uint16_t *peer_id_to_unpair);
 bool        fido_ble_unpairing_delete_peer_id(uint16_t peer_id_to_unpair);
 bool        fido_ble_unpairing_delete_all_peers(void);
+bool        fido_rtcc_get_timestamp(char *buf, size_t size);
+bool        fido_rtcc_set_timestamp(uint32_t seconds_since_epoch, uint8_t timezone_diff_hours);
 
 #ifdef __cplusplus
 }

--- a/nRF5340FW/square_devices_app/app/app_rtcc.c
+++ b/nRF5340FW/square_devices_app/app/app_rtcc.c
@@ -471,6 +471,11 @@ void app_rtcc_initialize(void)
 
 bool app_rtcc_set_timestamp(uint32_t seconds_since_epoch, uint8_t timezone_diff_hours)
 {
+    // RTCCが搭載されていない場合は終了
+    if (rtcc_is_available == false) {
+        return false;
+    }
+
     // UNIX時間を使って時刻合わせ
     //  UNIX時間カウンターには、引数をそのまま設定し、
     //  カレンダーには、タイムゾーンに対応した時刻を設定
@@ -487,6 +492,11 @@ bool app_rtcc_set_timestamp(uint32_t seconds_since_epoch, uint8_t timezone_diff_
 
 bool app_rtcc_get_timestamp(char *buf, size_t size)
 {
+    // RTCCが搭載されていない場合は終了
+    if (rtcc_is_available == false) {
+        return false;
+    }
+
     // レジスター（Clock register）から現在時刻を取得
     if (read_bytes_from_register(RV3028C7_REG_CLOCK_SECONDS, m_datetime, DATETIME_COMPONENTS_SIZE) == false) {
         return false;

--- a/nRF5340FW/square_devices_app/prj.conf
+++ b/nRF5340FW/square_devices_app/prj.conf
@@ -1,7 +1,7 @@
 #
 # for firmware revision control
 #
-CONFIG_APP_FW_BUILD=103
+CONFIG_APP_FW_BUILD=104
 
 #
 # for Bluetooth peripheral

--- a/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
+++ b/nRF5340FW/square_devices_app/wrapper/wrappper_common.c
@@ -100,3 +100,18 @@ bool fido_ble_unpairing_delete_all_peers(void)
 {
     return app_ble_unpairing_delete_all_peers(NULL);
 }
+
+//
+// RTCC関連
+//
+#include "app_rtcc.h"
+
+bool fido_rtcc_get_timestamp(char *buf, size_t size)
+{
+    return app_rtcc_get_timestamp(buf, size);
+}
+
+bool fido_rtcc_set_timestamp(uint32_t seconds_since_epoch, uint8_t timezone_diff_hours)
+{
+    return app_rtcc_set_timestamp(seconds_since_epoch, timezone_diff_hours);
+}


### PR DESCRIPTION
## 概要
現在制作中の[デスクトップツール](https://github.com/makmorit/SquareDevices/tree/main/DesktopTools)から、基板上のRTCC（リアルタイムクロック・カレンダー）に対し、現在時刻照会／設定が出来るよう、時刻同期機能をnRF5340ファームウェアに実装します。

RTCCは、Micro Crystal社製「[RV-3028-C7 32.768kHz 1ppm TA QC](https://www.mouser.jp/ProductDetail/Micro-Crystal/RV-3028-C7-32.768kHz-1ppm-TA-QC?qs=u16ybLDytRaU7ZFJl2AxfQ%3D%3D)」という部品を使用する前提とします。