### PR TITLE
[ファーム対応] 各種照会機能の実装

### DIFF
--- a/nRF5340FW/square_devices_app/prj.conf
+++ b/nRF5340FW/square_devices_app/prj.conf
@@ -1,7 +1,7 @@
 #
 # for firmware revision control
 #
-CONFIG_APP_FW_BUILD=104
+CONFIG_APP_FW_BUILD=105
 
 #
 # for Bluetooth peripheral


### PR DESCRIPTION
## 概要
現在制作中の[デスクトップツール](https://github.com/makmorit/SquareDevices/tree/main/DesktopTools)から、nRF5340ファームウェアに対し、Flash ROM情報照会／ファームウェアバージョン照会が出来るようにします。