### PR TITLE
[ファーム対応] ファームウェア更新機能の実装

### DIFF
--- a/nRF5340FW/square_devices_app/prj.conf
+++ b/nRF5340FW/square_devices_app/prj.conf
@@ -1,7 +1,7 @@
 #
 # for firmware revision control
 #
-CONFIG_APP_FW_BUILD=105
+CONFIG_APP_FW_BUILD=106
 
 #
 # for Bluetooth peripheral


### PR DESCRIPTION
## 概要
現在制作中の[デスクトップツール](https://github.com/makmorit/SquareDevices/tree/main/DesktopTools)から、nRF5340ファームウェアに対し、ファームウェアの更新（DFU）が出来るようにします。

DFUは、Zephyrプラットフォーム上で動作可能である「[MCUboot](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/mcuboot/index-ncs.html)」という仕組みを使用するものとします。