### PR TITLE
[Windows版ツール対応] BLEペアリング機能の実装

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessing.cs
@@ -1,0 +1,43 @@
+﻿using System.Windows;
+
+namespace DesktopTool.CommonWindow
+{
+    internal class CommonProcessing
+    {
+        private static readonly CommonProcessing Instance = new CommonProcessing();
+        private CommonProcessingWindow Window = null!;
+
+        private bool OpenFormInner(Window ownerWindow)
+        {
+            // この画面を、オーナー画面の中央にモード付きで表示
+            Window.Owner = ownerWindow;
+            bool? b = Window.ShowDialog();
+            if (b == null) {
+                return false;
+            } else {
+                return (bool)b;
+            }
+        }
+
+        private void NotifyTerminateInner()
+        {
+            // 処理進捗画面を閉じる
+            Window.Close();
+        }
+
+        //
+        // 公開用メソッド
+        //
+        public static bool OpenForm(Window owner)
+        {
+            Instance.Window = new CommonProcessingWindow();
+            return Instance.OpenFormInner(owner);
+        }
+
+        public static void NotifyTerminate()
+        {
+            Instance.NotifyTerminateInner();
+            Instance.Window = null!;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessingWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessingWindow.xaml
@@ -1,0 +1,11 @@
+﻿<Window x:Class="DesktopTool.CommonWindow.CommonProcessingWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="処理を実行中です。"  ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" SizeToContent="Height" Width="300" Cursor="Wait">
+    <Grid Height="75">
+        <Label x:Name="labelToolName" Content="しばらくお待ちください..." HorizontalAlignment="Left" Margin="25,20,0,0" VerticalAlignment="Top" Width="240" FontSize="14"/>
+    </Grid>
+</Window>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessingWindow.xaml.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonProcessingWindow.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Windows;
+
+namespace DesktopTool.CommonWindow
+{
+    /// <summary>
+    /// CommonProcessingWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class CommonProcessingWindow : Window
+    {
+        public CommonProcessingWindow()
+        {
+            InitializeComponent();
+        }
+
+        //
+        // 閉じるボタンの無効化
+        //
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            CommonWindowUtil.DisableCloseWindowButton(this);
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonWindowUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonWindowUtil.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Interop;
 
 namespace DesktopTool.CommonWindow
@@ -25,6 +27,30 @@ namespace DesktopTool.CommonWindow
             int style = GetWindowLong(handle, GWL_STYLE);
             style = style & (~WS_SYSMENU);
             SetWindowLong(handle, GWL_STYLE, style);
+        }
+    }
+
+    public class PasswordBoxUtil
+    {
+        public static bool CheckEntrySize(PasswordBox passwordBox, int minSize, int maxSize, string title, string informativeText, Window parentWindow)
+        {
+            int size = passwordBox.Password.Length;
+            if (size < minSize || size > maxSize) {
+                DialogUtil.ShowWarningMessage(parentWindow, title, informativeText);
+                passwordBox.Focus();
+                return false;
+            }
+            return true;
+        }
+
+        public static bool CheckIsNumeric(PasswordBox passwordBox, string title, string informativeText, Window parentWindow)
+        {
+            if (Regex.IsMatch(passwordBox.Password, "^[0-9]*$") == false) {
+                DialogUtil.ShowWarningMessage(parentWindow, title, informativeText);
+                passwordBox.Focus();
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonWindowUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/CommonWindow/CommonWindowUtil.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 
-namespace DesktopToolApp.CommonWindow
+namespace DesktopTool.CommonWindow
 {
     internal class CommonWindowUtil
     {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).003</FileVersion>
+    <FileVersion>$(Version).004</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj.user
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj.user
@@ -11,6 +11,9 @@
     <Compile Update="CommonWindow\CommonProcessingWindow.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="Functions\BLEConnection\BLEPairingCodeWindow.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="Functions\ToolCommon\ToolDoProcessView.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -29,6 +32,9 @@
   </ItemGroup>
   <ItemGroup>
     <Page Update="CommonWindow\CommonProcessingWindow.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Functions\BLEConnection\BLEPairingCodeWindow.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="Functions\ToolCommon\ToolDoProcessView.xaml">

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj.user
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj.user
@@ -8,6 +8,9 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="CommonWindow\CommonProcessingWindow.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="Functions\ToolCommon\ToolDoProcessView.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -25,6 +28,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Page Update="CommonWindow\CommonProcessingWindow.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Update="Functions\ToolCommon\ToolDoProcessView.xaml">
       <SubType>Designer</SubType>
     </Page>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -1,7 +1,7 @@
 ﻿using AppCommon;
 using DesktopTool.CommonWindow;
 using System;
-using System.Threading;
+using System.Net;
 using System.Threading.Tasks;
 using System.Windows;
 using static DesktopTool.FunctionMessage;
@@ -82,11 +82,25 @@ namespace DesktopTool
         protected override void InvokeProcessOnSubThread()
         {
             // TODO: 仮の実装です。
-            for (int i = 0; i < 7; i++) {
-                Thread.Sleep(1000);
-                string message = string.Format("{0} 秒が経過しました。", i + 1);
-                FunctionUtil.DisplayTextOnApp(message, ViewModel.AppendStatusText);
+            Application.Current.Dispatcher.Invoke(new Action(() => {
+                ShowPairingCodeWindow();
+            }));
+        }
+
+        private void ShowPairingCodeWindow()
+        {
+            // パスコード入力画面を表示
+            BLEPairingCode code = new BLEPairingCode();
+            if (code.OpenForm() == false) {
+                CancelProcess();
+                return;
             }
+
+            // パスコード入力画面からパスコードを取得
+            string passcode = new NetworkCredential(string.Empty, code.Passcode).Password;
+
+            // TODO: 仮の実装です。
+            FunctionUtil.DisplayTextOnApp(passcode, ViewModel.AppendStatusText);
             ResumeProcess(true);
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -87,7 +87,7 @@ namespace DesktopTool
                 string message = string.Format("{0} 秒が経過しました。", i + 1);
                 FunctionUtil.DisplayTextOnApp(message, ViewModel.AppendStatusText);
             }
-            ResumeProcess();
+            ResumeProcess(true);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -3,23 +3,8 @@ using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
-    internal class BLEPairingParameter
-    {
-        public ulong BluetoothAddress { get; set; }
-        public string ErrorMessage { get; set; }
-
-        public BLEPairingParameter()
-        {
-            BluetoothAddress = 0;
-            ErrorMessage = string.Empty;
-        }
-    }
-
     internal class BLEPairing : ToolDoProcess
     {
-        // パラメーターを保持
-        private BLEPairingParameter Parameter = null!;
-
         public BLEPairing(string menuItemName) : base(menuItemName) { }
 
         protected override void InvokeProcessOnSubThread()
@@ -33,11 +18,6 @@ namespace DesktopTool
 
         private void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
         {
-            // Bluetoothアドレス、エラーメッセージを設定
-            Parameter = new BLEPairingParameter();
-            Parameter.BluetoothAddress = parameter.BluetoothAddress;
-            Parameter.ErrorMessage = errorMessage;
-
             if (success == false) {
                 // 失敗時はログ出力
                 LogAndShowErrorMessage(errorMessage);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -1,10 +1,83 @@
-﻿using System.Threading;
+﻿using AppCommon;
+using DesktopTool.CommonWindow;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
+    internal class BLEPairingParameter
+    {
+        public ulong BluetoothAddress { get; set; }
+        public string Passcode { get; set; }
+        public string ErrorMessage { get; set; }
+
+        public BLEPairingParameter()
+        {
+            BluetoothAddress = 0;
+            Passcode = string.Empty;
+            ErrorMessage = string.Empty;
+        }
+    }
+
     internal class BLEPairing : ToolDoProcess
     {
+        // パラメーターを保持
+        private BLEPairingParameter Parameter = null!;
+
         public BLEPairing(string menuItemName) : base(menuItemName) { }
+
+        protected override void PreProcess()
+        {
+            Task task = Task.Run(() => {
+                // BLEデバイスをスキャン
+                BLEPeripheralScannerParam parameter = BLEPeripheralScannerParam.PrepareParameterForFIDO();
+                new BLEPeripheralScanner().DoProcess(parameter, OnBLEPeripheralScanned);
+            });
+
+            // 進捗画面を表示
+            Window mainWindow = Application.Current.MainWindow;
+            CommonProcessing.OpenForm(mainWindow);
+
+            // ペアリング対象のBLEデバイスが見つからなかった場合は終了
+            if (Parameter.BluetoothAddress == 0) {
+                DialogUtil.ShowWarningMessage(mainWindow, MenuItemName, Parameter.ErrorMessage);
+                return;
+            }
+
+            // 成功時はログ出力
+            AppLogUtil.OutputLogInfo(MSG_BLE_PAIRING_SCAN_SUCCESS);
+
+            // メイン画面右側の領域にビューを表示
+            base.PreProcess();
+        }
+
+        private void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
+        {
+            // Bluetoothアドレス、エラーメッセージを設定
+            Parameter = new BLEPairingParameter();
+            Parameter.BluetoothAddress = parameter.BluetoothAddress;
+            Parameter.ErrorMessage = errorMessage;
+
+            if (success == false) {
+                // 失敗時はログ出力
+                AppLogUtil.OutputLogError(errorMessage);
+
+            } else if (parameter.FIDOServiceDataFieldFound == false) {
+                // サービスデータフィールドがない場合は、エラー扱いとし、
+                // Bluetoothアドレスをゼロクリア
+                Parameter.BluetoothAddress = 0;
+                Parameter.ErrorMessage = MSG_BLE_PARING_ERR_PAIR_MODE;
+                AppLogUtil.OutputLogError(Parameter.ErrorMessage);
+            }
+
+            Application.Current.Dispatcher.Invoke(new Action(() => {
+                // 進捗画面を閉じる
+                CommonProcessing.NotifyTerminate();
+            }));
+        }
 
         protected override void InvokeProcessOnSubThread()
         {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -1,5 +1,4 @@
-﻿using AppCommon;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
@@ -41,23 +40,20 @@ namespace DesktopTool
 
             if (success == false) {
                 // 失敗時はログ出力
-                AppLogUtil.OutputLogError(errorMessage);
-                FunctionUtil.DisplayTextOnApp(errorMessage, ViewModel.AppendStatusText);
+                LogAndShowErrorMessage(errorMessage);
                 CancelProcess();
                 return;
             }
 
             if (parameter.FIDOServiceDataFieldFound == false) {
                 // サービスデータフィールドがない場合はエラー扱い
-                AppLogUtil.OutputLogError(MSG_BLE_PARING_ERR_PAIR_MODE);
-                FunctionUtil.DisplayTextOnApp(MSG_BLE_PARING_ERR_PAIR_MODE, ViewModel.AppendStatusText);
+                LogAndShowErrorMessage(MSG_BLE_PARING_ERR_PAIR_MODE);
                 CancelProcess();
                 return;
             }
 
             // 成功時はログ出力
-            AppLogUtil.OutputLogInfo(MSG_BLE_PAIRING_SCAN_SUCCESS);
-            FunctionUtil.DisplayTextOnApp(MSG_BLE_PAIRING_SCAN_SUCCESS, ViewModel.AppendStatusText);
+            LogAndShowInfoMessage(MSG_BLE_PAIRING_SCAN_SUCCESS);
             ResumeProcess(true);
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -11,13 +11,11 @@ namespace DesktopTool
     internal class BLEPairingParameter
     {
         public ulong BluetoothAddress { get; set; }
-        public string Passcode { get; set; }
         public string ErrorMessage { get; set; }
 
         public BLEPairingParameter()
         {
             BluetoothAddress = 0;
-            Passcode = string.Empty;
             ErrorMessage = string.Empty;
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Security;
+using System.Threading.Tasks;
+using System.Windows;
 using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
@@ -34,7 +37,55 @@ namespace DesktopTool
 
             // 成功時はログ出力
             LogAndShowInfoMessage(MSG_BLE_PAIRING_SCAN_SUCCESS);
-            ResumeProcess(true);
+
+            // ペアリング処理を実行
+            BLEPairingProcessParam processParam = new BLEPairingProcessParam(parameter.BluetoothAddress);
+            new BLEPairingProcess().DoProcess(processParam, OnRequestPairingCode, OnNotifyCommandTerminate);
+        }
+
+        //
+        // コールバック関数
+        //
+        public void OnRequestPairingCode(BLEPairingProcessParam parameter)
+        {
+            // パスコード入力画面を表示
+            Application.Current.Dispatcher.Invoke(new Action(() => {
+                ShowPairingCodeWindow(parameter);
+            }));
+        }
+
+        private void ShowPairingCodeWindow(BLEPairingProcessParam parameter)
+        {
+            // パスコード入力画面を表示
+            BLEPairingCode code = new BLEPairingCode();
+            if (code.OpenForm()) {
+                parameter.SecurePasscode = code.Passcode;
+                parameter.CancelPairing = false;
+            } else {
+                parameter.SecurePasscode = new SecureString();
+                parameter.CancelPairing = true;
+            }
+
+            // ヘルパークラスに制御を戻す
+            BLEPairingProcess.EnterPairingCode(parameter);
+        }
+
+        public void OnNotifyCommandTerminate(bool success, string errorMessage, BLEPairingProcessParam parameter)
+        {
+            if (parameter.CancelPairing) {
+                // ユーザー中止時に固有のメッセージを出力／表示
+                LogAndShowErrorMessage(errorMessage);
+
+                // 閉じるボタンを使用可能に設定
+                FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClose);
+
+            } else {
+                if (success == false) {
+                    // エラー発生時に固有のメッセージを出力／表示
+                    LogAndShowErrorMessage(errorMessage);
+                }
+                ResumeProcess(success);
+            }
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCode.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCode.cs
@@ -1,0 +1,89 @@
+﻿using DesktopTool.CommonWindow;
+using System.Security;
+using System.Windows;
+using static DesktopTool.FunctionMessage;
+
+namespace DesktopTool
+{
+    internal class BLEPairingCode
+    {
+        private static BLEPairingCode Instance = null!;
+        private BLEPairingCodeWindow Window = null!;
+
+        // 入力されたパスコードを保持
+        public SecureString Passcode { get; set; }
+
+        // パスコードの最小／最大桁数
+        private const int PASS_CODE_SIZE_MIN = 6;
+        private const int PASS_CODE_SIZE_MAX = 6;
+
+        public BLEPairingCode()
+        {
+            Passcode = new SecureString();
+            Instance = this;
+        }
+
+        public bool OpenForm()
+        {
+            // この画面を、オーナー画面の中央にモード付きで表示
+            Window = new BLEPairingCodeWindow();
+            Window.Owner = Application.Current.MainWindow; ;
+            bool? b = Window.ShowDialog();
+            if (b == null) {
+                return false;
+            } else {
+                return (bool)b;
+            }
+        }
+
+        private void NotifyTerminateInner(bool b)
+        {
+            // この画面を閉じる
+            Window.DialogResult = b;
+            Window.Close();
+            Window = null!;
+        }
+
+        //
+        // コールバック関数
+        //
+        public static void OnPairing(BLEPairingCodeViewModel model)
+        {
+            // 入力チェックがNGの場合は中止
+            BLEPairingCodeWindow window = Instance.Window;
+            if (CheckEntries(window) == false) {
+                return;
+            }
+
+            // 入力されたパスコードを保持
+            Instance.Passcode = model.PassCode;
+
+            // 画面を閉じる
+            Instance.NotifyTerminateInner(true);
+        }
+
+        public static void OnCancel(BLEPairingCodeViewModel model)
+        {
+            // 画面を閉じる
+            Instance.NotifyTerminateInner(false);
+        }
+
+        //
+        // 内部処理
+        //
+        private static bool CheckEntries(BLEPairingCodeWindow window)
+        {
+            // 長さチェック
+            if (PasswordBoxUtil.CheckEntrySize(window.passwordBoxPasscode, PASS_CODE_SIZE_MIN, PASS_CODE_SIZE_MAX, MSG_MENU_ITEM_NAME_BLE_PAIRING, MSG_PROMPT_INPUT_PAIRING_PASSCODE, window) == false) {
+                return false;
+            }
+
+            // 数字入力チェック
+            if (PasswordBoxUtil.CheckIsNumeric(window.passwordBoxPasscode, MSG_MENU_ITEM_NAME_BLE_PAIRING, MSG_PROMPT_INPUT_PAIRING_PASSCODE_NUM, window) == false) {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeViewModel.cs
@@ -1,0 +1,40 @@
+﻿using CommunityToolkit.Mvvm.Input;
+using System.Windows.Input;
+
+namespace DesktopTool
+{
+    internal class BLEPairingCodeViewModel : ViewModelBase
+    {
+        private readonly RelayCommand ButtonPairingClickedRelayCommand;
+        private readonly RelayCommand ButtonCloseClickedRelayCommand;
+
+        public BLEPairingCodeViewModel()
+        {
+            ButtonPairingClickedRelayCommand = new RelayCommand(OnButtonPairingClicked);
+            ButtonCloseClickedRelayCommand = new RelayCommand(OnButtonCloseClicked);
+        }
+
+        public ICommand ButtonPairingClicked
+        {
+            get { return ButtonPairingClickedRelayCommand; }
+        }
+
+        public ICommand ButtonCloseClicked
+        {
+            get { return ButtonCloseClickedRelayCommand; }
+        }
+
+        //
+        // 内部処理
+        //
+        private void OnButtonPairingClicked()
+        {
+            BLEPairingCode.OnPairing(this);
+        }
+
+        private void OnButtonCloseClicked()
+        {
+            BLEPairingCode.OnCancel(this);
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
+using System.Security;
 using System.Windows.Input;
 
 namespace DesktopTool
@@ -7,11 +8,13 @@ namespace DesktopTool
     {
         private readonly RelayCommand ButtonPairingClickedRelayCommand;
         private readonly RelayCommand ButtonCloseClickedRelayCommand;
+        private SecureString passcode = null!;
 
         public BLEPairingCodeViewModel()
         {
             ButtonPairingClickedRelayCommand = new RelayCommand(OnButtonPairingClicked);
             ButtonCloseClickedRelayCommand = new RelayCommand(OnButtonCloseClicked);
+            PassCode = new SecureString();
         }
 
         public ICommand ButtonPairingClicked
@@ -22,6 +25,12 @@ namespace DesktopTool
         public ICommand ButtonCloseClicked
         {
             get { return ButtonCloseClickedRelayCommand; }
+        }
+
+        public SecureString PassCode
+        {
+            get { return passcode; }
+            set { passcode = value; NotifyPropertyChanged(nameof(PassCode)); }
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
@@ -1,0 +1,15 @@
+﻿<Window x:Class="DesktopTool.BLEPairingCodeWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="ペアリング実行" Width="360" ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" SizeToContent="Height">
+    <Grid Height="150">
+        <Label x:Name="labelCaption" Content="基板に表示されたパスコードを入力し、&#xA;ペアリング実行ボタンをクリックしてください。" HorizontalAlignment="Center" VerticalAlignment="Top" VerticalContentAlignment="Center" Width="280" Height="40" Margin="0,10,0,0"/>
+        <Label x:Name="labelPasscode" Content="パスコード（半角数字6桁）" HorizontalAlignment="Left" Margin="42,56,0,0" VerticalAlignment="Top" Width="140"/>
+        <PasswordBox x:Name="passwordBoxPasscode" HorizontalAlignment="Left" Margin="192,61,0,0" VerticalAlignment="Top" Width="130"/>
+        <Button x:Name="buttonPairing" Content="ペアリング実行" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="120" Margin="50,100,0,0"/>
+        <Button x:Name="buttonCancel"  Content="中止" HorizontalAlignment="Left" Margin="190,100,0,0" VerticalAlignment="Top" Height="25" Width="120"/>
+    </Grid>
+</Window>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
@@ -3,13 +3,17 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:DesktopTool"
         mc:Ignorable="d"
         Title="ペアリング実行" Width="360" ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" SizeToContent="Height">
+    <Window.DataContext>
+        <vm:BLEPairingCodeViewModel />
+    </Window.DataContext>
     <Grid Height="150">
         <Label x:Name="labelCaption" Content="基板に表示されたパスコードを入力し、&#xA;ペアリング実行ボタンをクリックしてください。" HorizontalAlignment="Center" VerticalAlignment="Top" VerticalContentAlignment="Center" Width="280" Height="40" Margin="0,10,0,0"/>
         <Label x:Name="labelPasscode" Content="パスコード（半角数字6桁）" HorizontalAlignment="Left" Margin="42,56,0,0" VerticalAlignment="Top" Width="140"/>
         <PasswordBox x:Name="passwordBoxPasscode" HorizontalAlignment="Left" Margin="192,61,0,0" VerticalAlignment="Top" Width="130"/>
-        <Button x:Name="buttonPairing" Content="ペアリング実行" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="120" Margin="50,100,0,0"/>
-        <Button x:Name="buttonCancel"  Content="中止" HorizontalAlignment="Left" Margin="190,100,0,0" VerticalAlignment="Top" Height="25" Width="120"/>
+        <Button Content="ペアリング実行" Command="{Binding ButtonPairingClicked}" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="120" Margin="50,100,0,0"/>
+        <Button Content="中止" Command="{Binding ButtonCloseClicked}" HorizontalAlignment="Left" Margin="190,100,0,0" VerticalAlignment="Top" Height="25" Width="120"/>
     </Grid>
 </Window>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml
@@ -12,7 +12,7 @@
     <Grid Height="150">
         <Label x:Name="labelCaption" Content="基板に表示されたパスコードを入力し、&#xA;ペアリング実行ボタンをクリックしてください。" HorizontalAlignment="Center" VerticalAlignment="Top" VerticalContentAlignment="Center" Width="280" Height="40" Margin="0,10,0,0"/>
         <Label x:Name="labelPasscode" Content="パスコード（半角数字6桁）" HorizontalAlignment="Left" Margin="42,56,0,0" VerticalAlignment="Top" Width="140"/>
-        <PasswordBox x:Name="passwordBoxPasscode" HorizontalAlignment="Left" Margin="192,61,0,0" VerticalAlignment="Top" Width="130"/>
+        <PasswordBox x:Name="passwordBoxPasscode" PasswordChanged="passwordBoxPasscode_PasswordChanged" HorizontalAlignment="Left" Margin="192,61,0,0" VerticalAlignment="Top" Width="130"/>
         <Button Content="ペアリング実行" Command="{Binding ButtonPairingClicked}" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="120" Margin="50,100,0,0"/>
         <Button Content="中止" Command="{Binding ButtonCloseClicked}" HorizontalAlignment="Left" Margin="190,100,0,0" VerticalAlignment="Top" Height="25" Width="120"/>
     </Grid>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace DesktopTool
@@ -11,6 +12,11 @@ namespace DesktopTool
         public BLEPairingCodeWindow()
         {
             InitializeComponent();
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            passwordBoxPasscode.Focus();
         }
 
         private void passwordBoxPasscode_PasswordChanged(object sender, RoutedEventArgs e)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows;
+
+namespace DesktopTool
+{
+    /// <summary>
+    /// BLEPairingCodeWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class BLEPairingCodeWindow : Window
+    {
+        public BLEPairingCodeWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairingCodeWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
 
 namespace DesktopTool
 {
@@ -10,6 +11,16 @@ namespace DesktopTool
         public BLEPairingCodeWindow()
         {
             InitializeComponent();
+        }
+
+        private void passwordBoxPasscode_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (DataContext == null) {
+                return;
+            }
+            BLEPairingCodeViewModel dataContext = (BLEPairingCodeViewModel)DataContext;
+            PasswordBox passwordBox = (PasswordBox)sender;
+            dataContext.PassCode = passwordBox.SecurePassword;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersionInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersionInfo.cs
@@ -14,7 +14,7 @@ namespace DesktopTool
                 Thread.Sleep(1000);
             }
             FunctionUtil.DisplayTextOnApp(MSG_DEVICE_FW_VERSION_INFO_SHOWING, ViewModel.ShowCaption);
-            ResumeProcess();
+            ResumeProcess(true);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
@@ -71,12 +71,6 @@ namespace DesktopTool
                 DialogUtil.ShowWarningMessage(mainWindow, mainWindow.Title, message);
                 return;
             }
-
-            // サイドメニューを使用不能とする
-            SideMenuViewModel.EnableMenuItemSelection(false);
-            // サブ画面を領域内に表示
-            FunctionViewModel.ShowContentControl(true);
-
         }
 
         private static void ViewLogFileFolder()
@@ -98,6 +92,14 @@ namespace DesktopTool
         //
         // 外部公開用
         //
+        public static void ShowFunctionView()
+        {
+            // サイドメニューを使用不能とする
+            SideMenuViewModel.EnableMenuItemSelection(false);
+            // サブ画面を領域内に表示
+            FunctionViewModel.ShowContentControl(true);
+        }
+
         public static void HideFunctionView()
         {
             // サブ画面を領域から消す

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -27,6 +27,8 @@
         // BLEペアリング
         public const string MSG_BLE_PARING_ERR_PAIR_MODE = "ペアリング対象のBLEデバイスが、ペアリングモードでない可能性があります。BLEデバイスをペアリングモードに遷移させてください。";
         public const string MSG_BLE_PAIRING_SCAN_SUCCESS = "ペアリング対象のBLEデバイスがスキャンされました。";
+        public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE = "パスコードを６桁で入力してください";
+        public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE_NUM = "パスコードを数字で入力してください";
 
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -3,7 +3,9 @@
     class FunctionMessage
     {
         public const string MSG_FORMAT_START_MESSAGE = "{0}を開始します。";
-        public const string MSG_FORMAT_END_MESSAGE = "{0}が終了しました。";
+        public const string MSG_FORMAT_CANCEL_MESSAGE = "{0}が中断されました。";
+        public const string MSG_FORMAT_SUCCESS_MESSAGE = "{0}が成功しました。";
+        public const string MSG_FORMAT_FAILURE_MESSAGE = "{0}が失敗しました。";
         public const string MSG_FORMAT_PROCESSING_MESSAGE = "しばらくお待ちください...";
 
         public const string MSG_MENU_ITEM_NAME_BLE_SETTINGS = "BLE設定";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -24,6 +24,10 @@
         public const string MSG_FORMAT_ERROR_MENU_NOT_SUPPORTED = "メニュー「{0}」は実行できません。";
         public const string MSG_FORMAT_ERROR_CANNOT_VIEW_LOG_DIR = "ログファイル格納フォルダーを参照できませんでした。{0}";
 
+        // BLEペアリング
+        public const string MSG_BLE_PARING_ERR_PAIR_MODE = "ペアリング対象のBLEデバイスが、ペアリングモードでない可能性があります。BLEデバイスをペアリングモードに遷移させてください。";
+        public const string MSG_BLE_PAIRING_SCAN_SUCCESS = "ペアリング対象のBLEデバイスがスキャンされました。";
+
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
@@ -40,12 +40,11 @@ namespace DesktopTool
             DisplayTextOnApp(message, AppendStatusText);
         }
 
-        public static void ProcessTerminateLogWithName(string processName, Action<string> AppendStatusText)
+        public static void ProcessTerminateLogWithName(string messageFormat, string processName, Action<string> AppendStatusText)
         {
-            string message = string.Format(MSG_FORMAT_END_MESSAGE, processName);
+            string message = string.Format(messageFormat, processName);
             AppLogUtil.OutputLogInfo(message);
             DisplayTextOnApp(message, AppendStatusText);
         }
-
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -65,7 +65,8 @@ namespace DesktopTool
             ViewModel = model;
 
             // 画面のボタンを使用不可に設定
-            FunctionUtil.EnableButtonClickOnApp(false, ViewModel.EnableButtonClick);
+            FunctionUtil.EnableButtonClickOnApp(false, ViewModel.EnableButtonDoProcess);
+            FunctionUtil.EnableButtonClickOnApp(false, ViewModel.EnableButtonClose);
 
             Task task = Task.Run(() => {
                 // 処理開始メッセージを表示／ログ出力
@@ -86,8 +87,8 @@ namespace DesktopTool
             // 処理完了メッセージを表示／ログ出力
             FunctionUtil.ProcessTerminateLogWithName(success ? MSG_FORMAT_SUCCESS_MESSAGE : MSG_FORMAT_FAILURE_MESSAGE, MenuItemName, ViewModel.AppendStatusText);
 
-            // 画面のボタンを使用可能に設定
-            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClick);
+            // 閉じるボタンを使用可能に設定
+            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClose);
         }
 
         protected void CancelProcess()
@@ -95,8 +96,9 @@ namespace DesktopTool
             // 処理中止メッセージを表示／ログ出力
             FunctionUtil.ProcessTerminateLogWithName(MSG_FORMAT_CANCEL_MESSAGE, MenuItemName, ViewModel.AppendStatusText);
 
-            // 画面のボタンを使用可能に設定
-            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClick);
+            // 画面のボタンを使用不可に設定
+            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonDoProcess);
+            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClose);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
@@ -77,13 +78,22 @@ namespace DesktopTool
 
         protected virtual void InvokeProcessOnSubThread() 
         {
-            ResumeProcess();
+            ResumeProcess(true);
         }
 
-        protected void ResumeProcess()
+        protected void ResumeProcess(bool success)
         {
             // 処理完了メッセージを表示／ログ出力
-            FunctionUtil.ProcessTerminateLogWithName(MenuItemName, ViewModel.AppendStatusText);
+            FunctionUtil.ProcessTerminateLogWithName(success ? MSG_FORMAT_SUCCESS_MESSAGE : MSG_FORMAT_FAILURE_MESSAGE, MenuItemName, ViewModel.AppendStatusText);
+
+            // 画面のボタンを使用可能に設定
+            FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClick);
+        }
+
+        protected void CancelProcess()
+        {
+            // 処理中止メッセージを表示／ログ出力
+            FunctionUtil.ProcessTerminateLogWithName(MSG_FORMAT_CANCEL_MESSAGE, MenuItemName, ViewModel.AppendStatusText);
 
             // 画面のボタンを使用可能に設定
             FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClick);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using AppCommon;
+using System.Threading.Tasks;
 using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
@@ -99,6 +100,18 @@ namespace DesktopTool
             // 画面のボタンを使用不可に設定
             FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonDoProcess);
             FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClose);
+        }
+
+        protected void LogAndShowInfoMessage(string infoMessage)
+        {
+            AppLogUtil.OutputLogInfo(infoMessage);
+            FunctionUtil.DisplayTextOnApp(infoMessage, ViewModel.AppendStatusText);
+        }
+
+        protected void LogAndShowErrorMessage(string errorMessage)
+        {
+            AppLogUtil.OutputLogError(errorMessage);
+            FunctionUtil.DisplayTextOnApp(errorMessage, ViewModel.AppendStatusText);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -49,6 +49,7 @@ namespace DesktopTool
         {
             // メイン画面右側の領域にビューを表示
             FunctionView.SetViewContent(new ToolDoProcessView());
+            FunctionManager.ShowFunctionView();
         }
 
         private void InitFunctionViewInner(ToolDoProcessViewModel model)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -9,7 +9,7 @@ namespace DesktopTool
         public ToolDoProcessViewModel ViewModel = null!;
 
         // メニュー項目名称を保持
-        private string MenuItemName;
+        protected string MenuItemName;
 
         public ToolDoProcess(string menuItemName)
         {
@@ -19,8 +19,8 @@ namespace DesktopTool
             // メニュー項目名称を保持
             MenuItemName = menuItemName;
 
-            // メイン画面右側の領域にビューを表示
-            FunctionView.SetViewContent(new ToolDoProcessView());
+            // 画面表示前の処理を実行
+            Instance.PreProcess();
         }
 
         //
@@ -45,6 +45,12 @@ namespace DesktopTool
         //
         // 内部処理
         //
+        protected virtual void PreProcess()
+        {
+            // メイン画面右側の領域にビューを表示
+            FunctionView.SetViewContent(new ToolDoProcessView());
+        }
+
         private void InitFunctionViewInner(ToolDoProcessViewModel model)
         {
             // メニュー項目名を画面表示

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcessViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcessViewModel.cs
@@ -83,9 +83,13 @@ namespace DesktopTool
             ToolDoProcessView.AppendStatusText(text);
         }
 
-        public void EnableButtonClick(bool b)
+        public void EnableButtonDoProcess(bool b)
         {
             ButtonDoProcessIsEnabled = b;
+        }
+
+        public void EnableButtonClose(bool b)
+        {
             ButtonCloseIsEnabled = b;
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolShowInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolShowInfo.cs
@@ -71,13 +71,13 @@ namespace DesktopTool
 
         protected virtual void InvokeProcessOnSubThread()
         {
-            ResumeProcess();
+            ResumeProcess(true);
         }
 
-        protected void ResumeProcess()
+        protected void ResumeProcess(bool success)
         {
             // 処理完了メッセージを表示／ログ出力
-            FunctionUtil.ProcessTerminateLogWithName(MenuItemName, ViewModel.AppendStatusText);
+            FunctionUtil.ProcessTerminateLogWithName(success ? MSG_FORMAT_SUCCESS_MESSAGE : MSG_FORMAT_FAILURE_MESSAGE, MenuItemName, ViewModel.AppendStatusText);
 
             // 画面のボタンを使用可能に設定
             FunctionUtil.EnableButtonClickOnApp(true, ViewModel.EnableButtonClick);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolShowInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolShowInfo.cs
@@ -22,6 +22,7 @@ namespace DesktopTool
 
             // メイン画面右側の領域にビューを表示
             FunctionView.SetViewContent(new ToolShowInfoView());
+            FunctionManager.ShowFunctionView();
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolInfos/ToolVersionInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolInfos/ToolVersionInfo.cs
@@ -8,6 +8,7 @@ namespace DesktopTool
         {
             // メイン画面右側の領域にビューを表示
             FunctionView.SetViewContent(new ToolVersionInfoView());
+            FunctionManager.ShowFunctionView();
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -1,0 +1,10 @@
+﻿namespace DesktopTool
+{
+    internal class BLEDefines
+    {
+        // BLEサービスに関する定義
+        public const string U2F_BLE_SERVICE_UUID_STR = "0000FFFD-0000-1000-8000-00805f9b34fb";
+        public const string U2F_CONTROL_POINT_CHAR_UUID_STR = "F1D0FFF1-DEAA-ECEE-B42F-C9BA7ED623BB";
+        public const string U2F_STATUS_CHAR_UUID_STR = "F1D0FFF2-DEAA-ECEE-B42F-C9BA7ED623BB";
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPairingProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPairingProcess.cs
@@ -85,6 +85,7 @@ namespace DesktopTool
 
                 // ペアリングが正常終了したら処理完了
                 if (Parameter.CancelPairing) {
+                    errorMessage = MSG_BLE_PARING_ERR_CANCELED_BY_USER;
                     AppLogUtil.OutputLogError("Pairing canceled by user");
 
                 } else if (result.Status == DevicePairingResultStatus.Paired) {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPairingProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPairingProcess.cs
@@ -1,0 +1,143 @@
+﻿using AppCommon;
+using System;
+using System.Net;
+using System.Security;
+using Windows.Devices.Bluetooth;
+using Windows.Devices.Enumeration;
+using static DesktopTool.HelperMessage;
+
+namespace DesktopTool
+{
+    internal class BLEPairingProcessParam
+    {
+        public ulong BluetoothAddress { get; set; }
+        public bool CancelPairing { get; set; }
+        public SecureString SecurePasscode { get; set; }
+
+        // このクラスで設定
+        public DevicePairingRequestedEventArgs DevicePairingRequester { get; set; }
+
+        public BLEPairingProcessParam(ulong bluetoothAddress)
+        {
+            BluetoothAddress = bluetoothAddress;
+            CancelPairing = false;
+            SecurePasscode = new SecureString();
+            DevicePairingRequester = null!;
+        }
+    }
+
+    internal class BLEPairingProcess
+    {
+        // パラメーターを保持
+        private BLEPairingProcessParam Parameter = null!;
+
+        // 上位クラスに対するイベント通知
+        public delegate void RequestPairingCodeHandler(BLEPairingProcessParam parameter);
+        private event RequestPairingCodeHandler RequestPairingCode = null!;
+
+        public delegate void NotifyCommandTerminateHandler(bool success, string errorMessage, BLEPairingProcessParam parameter);
+        private event NotifyCommandTerminateHandler NotifyCommandTerminate = null!;
+
+        //
+        // 外部公開用
+        //
+        public void DoProcess(BLEPairingProcessParam param, RequestPairingCodeHandler requestPairingCode, NotifyCommandTerminateHandler notifyCommandTerminate)
+        {
+            // パラメーターの参照を保持
+            Parameter = param;
+
+            // 戻り先の関数を保持
+            RequestPairingCode += requestPairingCode;
+            NotifyCommandTerminate += notifyCommandTerminate;
+
+            // ペアリング対象デバイスとペアリングを実行
+            PairWithFIDOPeripheral(requestPairingCode != null);
+        }
+
+        //
+        // ペアリング実行
+        //
+        private async void PairWithFIDOPeripheral(bool needPairingCode)
+        {
+            // 変数を初期化
+            bool success = false;
+            string errorMessage = string.Empty;
+
+            try {
+                // デバイス情報を取得
+                BluetoothLEDevice? device = await BluetoothLEDevice.FromBluetoothAddressAsync(Parameter.BluetoothAddress);
+                DeviceInformation deviceInfoForPair = device.DeviceInformation;
+
+                // ペアリング実行
+                deviceInfoForPair.Pairing.Custom.PairingRequested += CustomOnPairingRequested;
+                DevicePairingResult result;
+                if (needPairingCode) {
+                    // パスキーが指定されている場合は、パスキーを使用
+                    result = await deviceInfoForPair.Pairing.Custom.PairAsync(
+                        DevicePairingKinds.ProvidePin, DevicePairingProtectionLevel.EncryptionAndAuthentication);
+
+                } else {
+                    // パスキーが指定されていない場合
+                    result = await deviceInfoForPair.Pairing.Custom.PairAsync(
+                        DevicePairingKinds.ConfirmOnly, DevicePairingProtectionLevel.Encryption);
+                }
+                deviceInfoForPair.Pairing.Custom.PairingRequested -= CustomOnPairingRequested;
+
+                // ペアリングが正常終了したら処理完了
+                if (Parameter.CancelPairing) {
+                    AppLogUtil.OutputLogError("Pairing canceled by user");
+
+                } else if (result.Status == DevicePairingResultStatus.Paired) {
+                    success = true;
+                    AppLogUtil.OutputLogDebug("Pairing with BLE device success");
+
+                } else if (result.Status == DevicePairingResultStatus.AlreadyPaired) {
+                    errorMessage = string.Format(MSG_BLE_PARING_ERR_ALREADY_PAIRED, deviceInfoForPair.Name);
+                    AppLogUtil.OutputLogError("Already paired with BLE device");
+
+                } else if (result.Status == DevicePairingResultStatus.Failed) {
+                    errorMessage = MSG_BLE_PARING_ERR_PROCESS;
+                    AppLogUtil.OutputLogError("Pairing with BLE device fail");
+
+                } else {
+                    errorMessage = MSG_BLE_PARING_ERR_UNKNOWN;
+                    AppLogUtil.OutputLogError(string.Format("Pairing with BLE device fail: reason={0}", result.Status));
+                }
+
+                // BLEデバイスを解放
+                device.Dispose();
+                device = null;
+
+            } catch (Exception e) {
+                errorMessage = MSG_BLE_PARING_ERR_UNKNOWN;
+                AppLogUtil.OutputLogError(string.Format("Pairing with BLE device fail: {0}", e.Message));
+            }
+
+            // 上位クラスに制御を戻す
+            NotifyCommandTerminate(success, errorMessage, Parameter);
+        }
+
+        //
+        // パスコード入力要求
+        //
+        private void CustomOnPairingRequested(DeviceInformationCustomPairing sender, DevicePairingRequestedEventArgs args)
+        {
+            if (args.PairingKind == DevicePairingKinds.ProvidePin) {
+                Parameter.DevicePairingRequester = args;
+                RequestPairingCode(Parameter);
+
+            } else {
+                args.Accept();
+            }
+        }
+
+        public static void EnterPairingCode(BLEPairingProcessParam parameter)
+        {
+            if (parameter.CancelPairing == false && parameter.SecurePasscode != null) {
+                // パスコードを取得して設定
+                string passcode = new NetworkCredential(string.Empty, parameter.SecurePasscode).Password;
+                parameter.DevicePairingRequester.Accept(passcode);
+            }
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPeripheralScanner.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPeripheralScanner.cs
@@ -1,0 +1,191 @@
+﻿using AppCommon;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Devices.Bluetooth.Advertisement;
+using Windows.Devices.Radios;
+using Windows.Storage.Streams;
+using static DesktopTool.BLEDefines;
+using static DesktopTool.HelperMessage;
+
+namespace DesktopTool
+{
+    internal class BLEPeripheralScannerParam
+    {
+        public Guid ServiceUUID { get; set; }
+        public Guid CharactForWriteUUID { get; set; }
+        public Guid CharactForReadUUID { get; set; }
+        public ulong BluetoothAddress { get; set; }
+        public byte[] ServiceDataField { get; set; }
+        public bool FIDOServiceDataFieldFound { get; set; }
+        public bool BLEPeripheralFound { get; set; }
+        public bool ConnectOnly { get; set; }
+
+        public BLEPeripheralScannerParam(string serviceUUIDString, string charactForWriteUUIDString, string charactForReadUUIDString)
+        {
+            ServiceUUID = new Guid(serviceUUIDString);
+            CharactForWriteUUID = new Guid(charactForWriteUUIDString);
+            CharactForReadUUID = new Guid(charactForReadUUIDString);
+            BluetoothAddress = 0;
+            ServiceDataField = Array.Empty<byte>();
+            FIDOServiceDataFieldFound = false;
+            BLEPeripheralFound = false;
+            ConnectOnly = false;
+        }
+
+        public static BLEPeripheralScannerParam PrepareParameterForFIDO()
+        {
+            return new BLEPeripheralScannerParam(U2F_BLE_SERVICE_UUID_STR, U2F_STATUS_CHAR_UUID_STR, U2F_CONTROL_POINT_CHAR_UUID_STR);
+        }
+    }
+
+    internal class BLEPeripheralScanner
+    {
+        // 上位クラスに対するイベント通知
+        public delegate void HandlerOnBLEPeripheralFound(bool success, string errorMessage, BLEPeripheralScannerParam parameter);
+        private event HandlerOnBLEPeripheralFound BLEPeripheralFound = null!;
+
+        // 戻り先の関数を保持
+        private HandlerOnBLEPeripheralFound HandlerRef = null!;
+
+        // スキャン処理のパラメーターを保持
+        private BLEPeripheralScannerParam Parameter = null!;
+
+        // スキャンに使用するWatcherを保持
+        private readonly BluetoothLEAdvertisementWatcher Watcher = null!;
+
+        // コンストラクター
+        public BLEPeripheralScanner()
+        {
+            // Watcherを初期化
+            Watcher = new BluetoothLEAdvertisementWatcher();
+            Watcher.Received += OnAdvertisementReceived;
+        }
+
+        public void DoProcess(BLEPeripheralScannerParam parameter, HandlerOnBLEPeripheralFound handler)
+        {
+            // パラメーターを保持
+            Parameter = parameter;
+
+            // 戻り先の関数を保持
+            HandlerRef = handler;
+            BLEPeripheralFound += HandlerRef;
+
+            // BLEデバイスを検索
+            ScanBLEPeripheral();
+        }
+
+        private void OnProcessTerminated(bool success, string errorMessage)
+        {
+            // スキャン結果情報、エラーメッセージを戻す
+            BLEPeripheralFound(success, errorMessage, Parameter);
+
+            // 呼出元クラスの関数コールバックを解除
+            BLEPeripheralFound -= HandlerRef;
+        }
+
+        //
+        // 内部処理
+        //
+        private async void ScanBLEPeripheral()
+        {
+            // Bluetoothがオンになっていることを確認
+            bool bton = false;
+            try {
+                var radios = await Radio.GetRadiosAsync();
+                foreach (var radio in radios) {
+                    if (radio.Kind == RadioKind.Bluetooth) {
+                        if (radio.State == RadioState.On) {
+                            bton = true;
+                            break;
+                        }
+                    }
+                }
+            } catch {
+                // Bluetoothオン状態が確認できない場合は失敗を通知
+                OnProcessTerminated(false, MSG_BLE_PARING_ERR_BT_STATUS_CANNOT_GET);
+                return;
+            }
+
+            if (bton == false) {
+                // Bluetoothがオンになっていない場合は失敗を通知
+                OnProcessTerminated(false, MSG_BLE_PARING_ERR_BT_OFF);
+                return;
+            }
+
+            // BLEデバイスからのアドバタイズ監視を開始
+            WatchAdvertisement();
+        }
+
+        private async void WatchAdvertisement()
+        {
+            // BLEデバイスからのアドバタイズ監視を開始
+            AppLogUtil.OutputLogDebug("Watch BLE device advertisement start");
+            Parameter.BluetoothAddress = 0;
+            Watcher.Start();
+
+            // BLEデバイスがみつかるまで待機（最大10秒）
+            for (int i = 0; i < 10 && Parameter.BluetoothAddress == 0; i++) {
+                await Task.Run(() => System.Threading.Thread.Sleep(1000));
+            }
+
+            // BLEデバイスからのアドバタイズ監視を終了
+            Watcher.Stop();
+            AppLogUtil.OutputLogDebug("Watch BLE device advertisement end");
+
+            if (Parameter.BluetoothAddress == 0) {
+                // BLEデバイスが見つからなかった場合は失敗を通知
+                OnProcessTerminated(false, MSG_BLE_PARING_ERR_TIMED_OUT);
+                return;
+            }
+
+            // FIDOのサービスデータフィールドが存在する場合はフラグを設定
+            byte[] expect = { 0xfd, 0xff, 0x80 };
+            if (Parameter.ServiceDataField.Length == 3 && Parameter.ServiceDataField.SequenceEqual(expect)) {
+                Parameter.FIDOServiceDataFieldFound = true;
+            }
+
+            // BLEデバイスが見つかった場合は成功を通知
+            Parameter.BLEPeripheralFound = true;
+            OnProcessTerminated(true, string.Empty);
+        }
+
+        private void OnAdvertisementReceived(BluetoothLEAdvertisementWatcher watcher, BluetoothLEAdvertisementReceivedEventArgs eventArgs)
+        {
+            // BLEデバイスが見つかったら、アドレス情報を保持し、画面スレッドに通知
+            foreach (Guid g in eventArgs.Advertisement.ServiceUuids) {
+                if (g.Equals(Parameter.ServiceUUID)) {
+                    Parameter.BluetoothAddress = eventArgs.BluetoothAddress;
+                    AppLogUtil.OutputLogDebug("BLE device found.");
+                    // アドバタイズデータからサービスデータフィールドを抽出
+                    Parameter.ServiceDataField = RetrieveServiceDataField(eventArgs.Advertisement);
+                    break;
+                }
+            }
+        }
+
+        private static byte[] RetrieveServiceDataField(BluetoothLEAdvertisement advertisement)
+        {
+            // アドバタイズデータを走査
+            byte[] serviceDataField = Array.Empty<byte>();
+            foreach (BluetoothLEAdvertisementDataSection datasection in advertisement.DataSections) {
+                // サービスデータフィールドの場合は格納領域に設定
+                byte dataType = datasection.DataType;
+                if (dataType == 0x16) {
+                    serviceDataField = new byte[datasection.Data.Length];
+                    using (DataReader reader = DataReader.FromBuffer(datasection.Data)) {
+                        reader.ReadBytes(serviceDataField);
+                        break;
+                    }
+                }
+            }
+            if (serviceDataField.Length == 0) {
+                AppLogUtil.OutputLogDebug("Service data field not found");
+            } else {
+                string dump = AppLogUtil.DumpMessage(serviceDataField, serviceDataField.Length);
+                AppLogUtil.OutputLogDebug(string.Format("Service data field found ({0} bytes) {1}", serviceDataField.Length, dump));
+            }
+            return serviceDataField;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -9,5 +9,6 @@
         public const string MSG_BLE_PARING_ERR_ALREADY_PAIRED = "ペアリング対象のBLEデバイスと既にペアリングされていたようです。WindowsのBluetooth環境設定画面から、デバイス「{0}」を削除した後、ペアリングを再実行してください。";
         public const string MSG_BLE_PARING_ERR_PROCESS = "BLEデバイスとのペアリング時にエラーが発生しました。";
         public const string MSG_BLE_PARING_ERR_UNKNOWN = "BLEデバイスとのペアリング時に不明なエラーが発生しました。";
+        public const string MSG_BLE_PARING_ERR_CANCELED_BY_USER = "BLEデバイスとのペアリング実行をユーザーが中止しました。";
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -1,0 +1,10 @@
+﻿namespace DesktopTool
+{
+    internal class HelperMessage
+    {
+        // BLEペアリング
+        public const string MSG_BLE_PARING_ERR_BT_STATUS_CANNOT_GET = "Bluetooth状態を確認できません。";
+        public const string MSG_BLE_PARING_ERR_BT_OFF = "Bluetoothがオフになっています。Bluetoothをオンにしてください。";
+        public const string MSG_BLE_PARING_ERR_TIMED_OUT = "ペアリング対象のBLEデバイスが停止している可能性があります。BLEデバイスの電源を入れ、PCのUSBポートから外してください。";
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -6,7 +6,7 @@
         public const string MSG_BLE_PARING_ERR_BT_STATUS_CANNOT_GET = "Bluetooth状態を確認できません。";
         public const string MSG_BLE_PARING_ERR_BT_OFF = "Bluetoothがオフになっています。Bluetoothをオンにしてください。";
         public const string MSG_BLE_PARING_ERR_TIMED_OUT = "ペアリング対象のBLEデバイスが停止している可能性があります。BLEデバイスの電源を入れ、PCのUSBポートから外してください。";
-        public const string MSG_BLE_PARING_ERR_ALREADY_PAIRED = "ペアリング対象のBLEデバイスと既にペアリングされていたようです。\nWindowsのBluetooth環境設定画面から、デバイス「{0}」を削除した後、ペアリングを再実行してください。";
+        public const string MSG_BLE_PARING_ERR_ALREADY_PAIRED = "ペアリング対象のBLEデバイスと既にペアリングされていたようです。WindowsのBluetooth環境設定画面から、デバイス「{0}」を削除した後、ペアリングを再実行してください。";
         public const string MSG_BLE_PARING_ERR_PROCESS = "BLEデバイスとのペアリング時にエラーが発生しました。";
         public const string MSG_BLE_PARING_ERR_UNKNOWN = "BLEデバイスとのペアリング時に不明なエラーが発生しました。";
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -6,5 +6,8 @@
         public const string MSG_BLE_PARING_ERR_BT_STATUS_CANNOT_GET = "Bluetooth状態を確認できません。";
         public const string MSG_BLE_PARING_ERR_BT_OFF = "Bluetoothがオフになっています。Bluetoothをオンにしてください。";
         public const string MSG_BLE_PARING_ERR_TIMED_OUT = "ペアリング対象のBLEデバイスが停止している可能性があります。BLEデバイスの電源を入れ、PCのUSBポートから外してください。";
+        public const string MSG_BLE_PARING_ERR_ALREADY_PAIRED = "ペアリング対象のBLEデバイスと既にペアリングされていたようです。\nWindowsのBluetooth環境設定画面から、デバイス「{0}」を削除した後、ペアリングを再実行してください。";
+        public const string MSG_BLE_PARING_ERR_PROCESS = "BLEデバイスとのペアリング時にエラーが発生しました。";
+        public const string MSG_BLE_PARING_ERR_UNKNOWN = "BLEデバイスとのペアリング時に不明なエラーが発生しました。";
     }
 }


### PR DESCRIPTION
## 概要
Windows版デスクトップツールに、BLEペアリング機能を実装します。

#### 前提
ペアリング相手は[nRF5340アプリケーション](https://github.com/makmorit/SquareDevices/tree/main/nRF5340FW/square_devices_app)が動作する基板とします。