### PR TITLE
[Windows版ツール対応] ペアリング情報削除機能の実装

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/AppCommon/CommonTimer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/AppCommon/CommonTimer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Timers;
+
+namespace AppCommon
+{
+    internal class CommonTimer
+    {
+        // タイマーオブジェクト
+        private readonly Timer Timer = null!;
+
+        // タイムアウトイベント
+        public delegate void CommandTimeoutEventHandler(object sender, EventArgs e);
+        public event CommandTimeoutEventHandler CommandTimeoutEvent = null!;
+
+        // タイマー名称
+        //（個別のタイマースレッドを識別するための名称）
+        private readonly string TimerName;
+
+        // 応答タイムアウト監視制御
+        private bool TimerStarted = false;
+
+        public CommonTimer(string n, int ms)
+        {
+            TimerName = n;
+            Timer = new Timer(ms);
+        }
+
+        public void Start()
+        {
+            if (TimerStarted) {
+                return;
+            }
+            TimerStarted = true;
+            Timer.Elapsed += CommandTimerElapsed;
+            Timer.Start();
+        }
+
+        public void Stop()
+        {
+            if (TimerStarted == false) {
+                return;
+            }
+            TimerStarted = false;
+            Timer.Stop();
+            Timer.Elapsed -= CommandTimerElapsed;
+        }
+
+        private void CommandTimerElapsed(object? sender, EventArgs e)
+        {
+            if (sender == null) {
+                return;
+            }
+
+            try {
+                // イベントを送出
+                CommandTimeoutEvent(sender, e);
+
+            } catch (Exception ex) {
+                AppLogUtil.OutputLogError(string.Format("CommonTimer({0}): {1}", TimerName, ex.Message));
+
+            } finally {
+                Stop();
+            }
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).004</FileVersion>
+    <FileVersion>$(Version).005</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,7 +1,42 @@
-﻿namespace DesktopTool
+﻿using System.Threading.Tasks;
+using static DesktopTool.FunctionMessage;
+
+namespace DesktopTool
 {
     internal class EraseBondingInfo : ToolDoProcess
     {
         public EraseBondingInfo(string menuItemName) : base(menuItemName) { }
+
+        protected override void InvokeProcessOnSubThread()
+        {
+            Task task = Task.Run(() => {
+                // BLEデバイスをスキャン
+                BLEPeripheralScannerParam parameter = BLEPeripheralScannerParam.PrepareParameterForFIDO();
+                new BLEPeripheralScanner().DoProcess(parameter, OnBLEPeripheralScanned);
+            });
+        }
+
+        private void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
+        {
+            if (success == false) {
+                // 失敗時はログ出力
+                LogAndShowErrorMessage(errorMessage);
+                CancelProcess();
+                return;
+            }
+
+            if (parameter.FIDOServiceDataFieldFound) {
+                // ペアリングモード時（＝サービスデータフィールドが存在する場合）はエラー扱い
+                LogAndShowErrorMessage(MSG_ERROR_FUNCTION_IN_PAIRING_MODE);
+                CancelProcess();
+                return;
+            }
+
+            // 成功時はログ出力
+            LogAndShowInfoMessage(MSG_SCAN_BLE_DEVICE_SUCCESS);
+
+            // TODO: 仮の実装です。
+            base.InvokeProcessOnSubThread();
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -39,7 +39,7 @@ namespace DesktopTool
             // サービスに接続
             BLEServiceParam serviceParam = new BLEServiceParam(parameter);
             BLEService service = new BLEService();
-            await service.StartCommunicate(serviceParam);
+            await service.StartCommunicate(serviceParam, OnConnectionStatusChanged);
 
             if (service.IsConnected()) {
                 // 接続成功の場合
@@ -56,6 +56,15 @@ namespace DesktopTool
 
             // TODO: 仮の実装です。
             base.InvokeProcessOnSubThread();
+        }
+
+        private void OnConnectionStatusChanged(BLEService service, bool connected)
+        {
+            if (connected == false) {
+                // 切断検知時は、接続を終了させる
+                service.Disconnect();
+                AppLogUtil.OutputLogInfo(MSG_DISCONNECT_BLE_DEVICE);
+            }
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using static DesktopTool.FunctionMessage;
+using static DesktopTool.FunctionDefines;
 
 namespace DesktopTool
 {
@@ -78,7 +79,7 @@ namespace DesktopTool
         private void PerformInquiryCommand(BLETransport sender)
         {
             // ペアリング情報削除コマンド（１回目）を実行
-            sender.SendRequest(0x83, new byte[] { 0x4f });
+            sender.SendRequest(0x80 | U2F_COMMAND_MSG, new byte[] { VENDOR_COMMAND_ERASE_BONDING_DATA });
         }
 
         private void PerformExecuteCommand(BLETransport sender, byte[] responseBytes)
@@ -87,10 +88,10 @@ namespace DesktopTool
             byte[] PeerID = responseBytes.Skip(1).ToArray();
 
             // 送信フレームを生成
-            byte[] frame = new byte[] { 0x4f }.Concat(PeerID).ToArray();
+            byte[] frame = new byte[] { VENDOR_COMMAND_ERASE_BONDING_DATA }.Concat(PeerID).ToArray();
 
             // ペアリング情報削除コマンド（２回目）を実行
-            sender.SendRequest(0x83, frame);
+            sender.SendRequest(0x80 | U2F_COMMAND_MSG, frame);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
@@ -23,9 +25,72 @@ namespace DesktopTool
                 return;
             }
 
-            // 後続処理を実行
+            // コールバックを登録
+            sender.RegisterResponseReceivedHandler(ResponseReceivedHandler);
+
+            // ペアリング情報削除コマンド（１回目）を実行
+            PerformInquiryCommand(sender);
+        }
+
+        private void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
+        {
+            if (success == false) {
+                TerminateCommand(sender, false, errorMessage);
+                return;
+            }
+
+            byte status = responseBytes[0];
+            if (status != 0) {
+                TerminateCommand(sender, false, string.Format(MSG_FORMAT_OCCUR_UNKNOWN_ERROR_ST, status));
+                return;
+            }
+
+            if (responseBytes.Length == 3) {
+                // ペアリング情報削除コマンド（２回目）を実行
+                PerformExecuteCommand(sender, responseBytes);
+
+            } else {
+                // 正常終了
+                TerminateCommand(sender, true, string.Empty);
+            }
+        }
+
+        private void TerminateCommand(BLETransport sender, bool success, string errorMessage)
+        {
+            // コールバックを解除
+            sender.UnregisterResponseReceivedHandler(ResponseReceivedHandler);
+
+            // 接続を終了
             sender.Disconnect();
+
+            if (success == false) {
+                // 失敗時はログ出力
+                LogAndShowErrorMessage(errorMessage);
+            }
+
+            // 後続処理を実行
             ResumeProcess(success);
+        }
+
+        //
+        // 内部処理
+        //
+        private void PerformInquiryCommand(BLETransport sender)
+        {
+            // ペアリング情報削除コマンド（１回目）を実行
+            sender.SendRequest(0x83, new byte[] { 0x4f });
+        }
+
+        private void PerformExecuteCommand(BLETransport sender, byte[] responseBytes)
+        {
+            // コマンド引数となるPeer IDを抽出
+            byte[] PeerID = responseBytes.Skip(1).ToArray();
+
+            // 送信フレームを生成
+            byte[] frame = new byte[] { 0x4f }.Concat(PeerID).ToArray();
+
+            // ペアリング情報削除コマンド（２回目）を実行
+            sender.SendRequest(0x83, frame);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -79,7 +79,7 @@ namespace DesktopTool
         private void PerformInquiryCommand(BLETransport sender)
         {
             // ペアリング情報削除コマンド（１回目）を実行
-            sender.SendRequest(0x80 | U2F_COMMAND_MSG, new byte[] { VENDOR_COMMAND_ERASE_BONDING_DATA });
+            sender.SendRequest(U2F_COMMAND_MSG, new byte[] { VENDOR_COMMAND_ERASE_BONDING_DATA });
         }
 
         private void PerformExecuteCommand(BLETransport sender, byte[] responseBytes)
@@ -91,7 +91,7 @@ namespace DesktopTool
             byte[] frame = new byte[] { VENDOR_COMMAND_ERASE_BONDING_DATA }.Concat(PeerID).ToArray();
 
             // ペアリング情報削除コマンド（２回目）を実行
-            sender.SendRequest(0x80 | U2F_COMMAND_MSG, frame);
+            sender.SendRequest(U2F_COMMAND_MSG, frame);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using AppCommon;
+using System.Threading.Tasks;
 using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
@@ -16,7 +17,7 @@ namespace DesktopTool
             });
         }
 
-        private void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
+        private async void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
         {
             if (success == false) {
                 // 失敗時はログ出力
@@ -34,6 +35,24 @@ namespace DesktopTool
 
             // 成功時はログ出力
             LogAndShowInfoMessage(MSG_SCAN_BLE_DEVICE_SUCCESS);
+
+            // サービスに接続
+            BLEServiceParam serviceParam = new BLEServiceParam(parameter);
+            BLEService service = new BLEService();
+            await service.StartCommunicate(serviceParam);
+
+            if (service.IsConnected()) {
+                // 接続成功の場合
+                AppLogUtil.OutputLogInfo(MSG_CONNECT_BLE_DEVICE_SUCCESS);
+
+                // TODO: 仮の実装です。
+                service.Disconnect();
+                AppLogUtil.OutputLogInfo(MSG_DISCONNECT_BLE_DEVICE);
+
+            } else {
+                // 接続失敗の場合
+                AppLogUtil.OutputLogInfo(MSG_CONNECT_BLE_DEVICE_FAILURE);
+            }
 
             // TODO: 仮の実装です。
             base.InvokeProcessOnSubThread();

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,0 +1,7 @@
+﻿namespace DesktopTool
+{
+    internal class EraseBondingInfo : ToolDoProcess
+    {
+        public EraseBondingInfo(string menuItemName) : base(menuItemName) { }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -41,7 +41,7 @@ namespace DesktopTool
             }
 
             byte status = responseBytes[0];
-            if (status != 0) {
+            if (status != CTAP1_ERR_SUCCESS) {
                 TerminateCommand(sender, false, string.Format(MSG_FORMAT_OCCUR_UNKNOWN_ERROR_ST, status));
                 return;
             }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
@@ -8,6 +8,7 @@ namespace DesktopTool
         public const byte CTAP1_ERR_SUCCESS = 0x00;
 
         // U2Fコマンド
+        public const byte U2F_COMMAND_KEEPALIVE = 0x02;
         public const byte U2F_COMMAND_MSG = 0x03;
 
         // ベンダー固有コマンド

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
@@ -1,7 +1,12 @@
-﻿namespace DesktopTool
+﻿using System;
+
+namespace DesktopTool
 {
     internal class FunctionDefines
     {
+        // FIDO機能関連エラーステータス
+        public const byte CTAP1_ERR_SUCCESS = 0x00;
+
         // U2Fコマンド
         public const byte U2F_COMMAND_MSG = 0x03;
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
@@ -1,0 +1,11 @@
+﻿namespace DesktopTool
+{
+    internal class FunctionDefines
+    {
+        // U2Fコマンド
+        public const byte U2F_COMMAND_MSG = 0x03;
+
+        // ベンダー固有コマンド
+        public const byte VENDOR_COMMAND_ERASE_BONDING_DATA = 0x4f;
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
@@ -58,6 +58,9 @@ namespace DesktopTool
             if (menuItemName.Equals(MSG_MENU_ITEM_NAME_BLE_PAIRING)) {
                 new BLEPairing(menuItemName);
 
+            } else if (menuItemName.Equals(MSG_MENU_ITEM_NAME_BLE_ERASE_BOND)) {
+                new EraseBondingInfo(menuItemName);
+
             } else if (menuItemName.Equals(MSG_MENU_ITEM_NAME_GET_FLASH_STAT)) {
                 new FWVersionInfo(menuItemName);
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -34,6 +34,9 @@
 
         public const string MSG_ERROR_FUNCTION_IN_PAIRING_MODE = "ペアリングモードでは、ペアリング実行以外の機能は使用できません。ペアリングモードを解除してから、機能を再度実行してください。";
         public const string MSG_SCAN_BLE_DEVICE_SUCCESS = "対象のBLEデバイスがスキャンされました。";
+        public const string MSG_CONNECT_BLE_DEVICE_FAILURE = "BLEデバイスの接続に失敗しました。";
+        public const string MSG_CONNECT_BLE_DEVICE_SUCCESS = "BLEデバイスに接続しました。";
+        public const string MSG_DISCONNECT_BLE_DEVICE = "BLEデバイスから切断しました。";
 
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -32,12 +32,6 @@
         public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE = "パスコードを６桁で入力してください";
         public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE_NUM = "パスコードを数字で入力してください";
 
-        public const string MSG_ERROR_FUNCTION_IN_PAIRING_MODE = "ペアリングモードでは、ペアリング実行以外の機能は使用できません。ペアリングモードを解除してから、機能を再度実行してください。";
-        public const string MSG_SCAN_BLE_DEVICE_SUCCESS = "対象のBLEデバイスがスキャンされました。";
-        public const string MSG_CONNECT_BLE_DEVICE_FAILURE = "BLEデバイスの接続に失敗しました。";
-        public const string MSG_CONNECT_BLE_DEVICE_SUCCESS = "BLEデバイスに接続しました。";
-        public const string MSG_DISCONNECT_BLE_DEVICE = "BLEデバイスから切断しました。";
-
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -7,6 +7,7 @@
         public const string MSG_FORMAT_SUCCESS_MESSAGE = "{0}が成功しました。";
         public const string MSG_FORMAT_FAILURE_MESSAGE = "{0}が失敗しました。";
         public const string MSG_FORMAT_PROCESSING_MESSAGE = "しばらくお待ちください...";
+        public const string MSG_FORMAT_OCCUR_UNKNOWN_ERROR_ST = "不明なエラーが発生しました（Status=0x{0:x2}）";
 
         public const string MSG_MENU_ITEM_NAME_BLE_SETTINGS = "BLE設定";
         public const string MSG_MENU_ITEM_NAME_BLE_PAIRING = "ペアリング実行";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -32,6 +32,9 @@
         public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE = "パスコードを６桁で入力してください";
         public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE_NUM = "パスコードを数字で入力してください";
 
+        public const string MSG_ERROR_FUNCTION_IN_PAIRING_MODE = "ペアリングモードでは、ペアリング実行以外の機能は使用できません。ペアリングモードを解除してから、機能を再度実行してください。";
+        public const string MSG_SCAN_BLE_DEVICE_SUCCESS = "対象のBLEデバイスがスキャンされました。";
+
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Windows;
 using static DesktopTool.FunctionMessage;
+using static DesktopTool.FunctionDefines;
 
 namespace DesktopTool
 {
@@ -45,6 +46,14 @@ namespace DesktopTool
             string message = string.Format(messageFormat, processName);
             AppLogUtil.OutputLogInfo(message);
             DisplayTextOnApp(message, AppendStatusText);
+        }
+
+        //
+        // ユーティリティー
+        //
+        public static bool CommandIsU2FKeepAlive(byte CMD)
+        {
+            return (CMD == U2F_COMMAND_KEEPALIVE);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -6,5 +6,8 @@
         public const string U2F_BLE_SERVICE_UUID_STR = "0000FFFD-0000-1000-8000-00805f9b34fb";
         public const string U2F_CONTROL_POINT_CHAR_UUID_STR = "F1D0FFF1-DEAA-ECEE-B42F-C9BA7ED623BB";
         public const string U2F_STATUS_CHAR_UUID_STR = "F1D0FFF2-DEAA-ECEE-B42F-C9BA7ED623BB";
+
+        // 定数
+        public const uint WINDOWS_ERROR_NO_MORE_FILES = 0x80650012;
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -12,6 +12,9 @@
         public const int U2F_BLE_CONT_HEADER_LEN = 1;
         public const int U2F_BLE_FRAME_LEN = 64;
 
+        // 性能関連
+        public const int U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC = 3000;
+
         // 定数
         public const uint WINDOWS_ERROR_NO_MORE_FILES = 0x80650012;
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -7,6 +7,11 @@
         public const string U2F_CONTROL_POINT_CHAR_UUID_STR = "F1D0FFF1-DEAA-ECEE-B42F-C9BA7ED623BB";
         public const string U2F_STATUS_CHAR_UUID_STR = "F1D0FFF2-DEAA-ECEE-B42F-C9BA7ED623BB";
 
+        // BLEフレームに関する定数
+        public const int U2F_BLE_INIT_HEADER_LEN = 3;
+        public const int U2F_BLE_CONT_HEADER_LEN = 1;
+        public const int U2F_BLE_FRAME_LEN = 64;
+
         // 定数
         public const uint WINDOWS_ERROR_NO_MORE_FILES = 0x80650012;
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -1,0 +1,215 @@
+﻿using AppCommon;
+using System;
+using System.Threading.Tasks;
+using Windows.Devices.Bluetooth;
+using Windows.Devices.Bluetooth.GenericAttributeProfile;
+using static DesktopTool.HelperMessage;
+
+namespace DesktopTool
+{
+    internal class BLEServiceParam
+    {
+        public Guid ServiceUUID { get; set; }
+        public Guid CharactForWriteUUID { get; set; }
+        public Guid CharactForReadUUID { get; set; }
+        public ulong BluetoothAddress { get; set; }
+
+        public BLEServiceParam(BLEPeripheralScannerParam param)
+        {
+            ServiceUUID = param.ServiceUUID;
+            CharactForWriteUUID = param.CharactForWriteUUID;
+            CharactForReadUUID = param.CharactForReadUUID;
+            BluetoothAddress = param.BluetoothAddress;
+        }
+    }
+
+    internal class BLEService
+    {
+        //
+        // BLE接続／送受信関連
+        //
+        // サービスをディスカバーできたデバイスを保持
+        private BluetoothLEDevice BluetoothLEDevice = null!;
+        private GattDeviceService BLEservice = null!;
+        private GattCharacteristic U2FStatusChar = null!;
+
+        // ステータスを保持
+        private GattCommunicationStatus CommunicationStatus;
+
+        public async Task<bool> StartCommunicate(BLEServiceParam parameter)
+        {
+            // Bluetoothアドレスが不正の場合は処理を実行しない
+            if (parameter.BluetoothAddress == 0) {
+                FreeResources();
+                return false;
+            }
+
+            // サービスをディスカバー
+            if (await DiscoverBLEService(parameter) == false) {
+                FreeResources();
+                return false;
+            }
+
+            //
+            // データ受信監視を開始
+            // リトライ上限は３回とする
+            //
+            int retry = 3;
+            for (int k = 0; k < retry + 1; k++) {
+                if (k > 0) {
+                    AppLogUtil.OutputLogWarn(string.Format(MSG_BLE_U2F_NOTIFICATION_RETRY, k));
+                    await Task.Run(() => System.Threading.Thread.Sleep(100));
+                }
+
+                if (await StartBLENotification(BLEservice, parameter)) {
+                    AppLogUtil.OutputLogInfo(string.Format("{0}({1})", MSG_BLE_U2F_NOTIFICATION_START, BLEservice.Device.Name));
+                    return true;
+                }
+
+                // 物理接続がない場合は再試行せず、明示的に接続オブジェクトを破棄
+                if (CommunicationStatus == GattCommunicationStatus.Unreachable) {
+                    StopCommunicate();
+                    return false;
+                }
+            }
+
+            // 接続されなかった場合は false
+            AppLogUtil.OutputLogError(string.Format("{0}({1})", MSG_BLE_U2F_NOTIFICATION_FAILED, BLEservice.Device.Name));
+            return false;
+        }
+
+        private async Task<bool> DiscoverBLEService(BLEServiceParam parameter)
+        {
+            try {
+                AppLogUtil.OutputLogInfo(string.Format(MSG_BLE_U2F_SERVICE_FINDING, parameter.ServiceUUID));
+                BluetoothLEDevice = await BluetoothLEDevice.FromBluetoothAddressAsync(parameter.BluetoothAddress);
+                if (BluetoothLEDevice == null) {
+                    AppLogUtil.OutputLogError(MSG_BLE_U2F_DEVICE_NOT_FOUND);
+                    return false;
+                }
+
+                var gattServices = await BluetoothLEDevice.GetGattServicesAsync();
+                foreach (var gattService in gattServices.Services) {
+                    if (gattService.Uuid.Equals(parameter.ServiceUUID)) {
+                        BLEservice = gattService;
+                        AppLogUtil.OutputLogDebug(string.Format("  FIDO BLE service found [{0}]", gattService.Device.Name));
+                    }
+                }
+
+                if (BLEservice == null) {
+                    AppLogUtil.OutputLogError(MSG_BLE_U2F_SERVICE_NOT_FOUND);
+                    return false;
+                }
+
+                // 接続・切断検知ができるようにする
+                BluetoothLEDevice.ConnectionStatusChanged += BLEConnectionStatusChanged;
+
+                AppLogUtil.OutputLogInfo(MSG_BLE_U2F_SERVICE_FOUND);
+                return true;
+
+            } catch (Exception e) {
+                AppLogUtil.OutputLogError(string.Format("BLEService.DiscoverBLEService: {0}", e.Message));
+                return false;
+            }
+        }
+
+        private async Task<bool> StartBLENotification(GattDeviceService service, BLEServiceParam parameter)
+        {
+            // ステータスを初期化（戻りの有無を上位関数で判別できるようにするため）
+            CommunicationStatus = GattCommunicationStatus.Success;
+
+            try {
+                U2FStatusChar = service.GetCharacteristics(parameter.CharactForWriteUUID)[0];
+
+                CommunicationStatus = await U2FStatusChar.WriteClientCharacteristicConfigurationDescriptorAsync(
+                    GattClientCharacteristicConfigurationDescriptorValue.Notify);
+                if (CommunicationStatus != GattCommunicationStatus.Success) {
+                    AppLogUtil.OutputLogDebug(string.Format("BLEService.StartBLENotification: GattCommunicationStatus={0}", CommunicationStatus));
+                    return false;
+                }
+
+                // 監視開始したサービスを退避
+                BLEservice = service;
+                return true;
+
+            } catch (Exception e) {
+                AppLogUtil.OutputLogError(string.Format("BLEService.StartBLENotification: {0}", e.Message));
+                return false;
+            }
+        }
+
+        //
+        // 切断処理
+        //
+        public void Disconnect()
+        {
+            // 接続ずみの場合はBLEデバイスを切断
+            if (IsConnected()) {
+                StopCommunicate();
+            }
+        }
+
+        private void StopCommunicate()
+        {
+            try {
+                if (BLEservice != null) {
+                    BLEservice.Dispose();
+                }
+                if (BluetoothLEDevice != null) {
+                    BluetoothLEDevice.ConnectionStatusChanged -= BLEConnectionStatusChanged;
+                    BluetoothLEDevice.Dispose();
+                }
+
+            } catch (Exception e) {
+                AppLogUtil.OutputLogError(string.Format("BLEService.StopCommunicate: {0}", e.Message));
+
+            } finally {
+                FreeResources();
+            }
+        }
+
+        public bool IsConnected()
+        {
+            if (BluetoothLEDevice == null) {
+                // 接続されていない場合は false
+                return false;
+            }
+
+            if (BLEservice == null) {
+                // データ受信ができない場合は false
+                return false;
+            }
+
+            // BLE接続されている場合は true
+            return true;
+        }
+
+        private void FreeResources()
+        {
+            // オブジェクトへの参照を解除
+            BluetoothLEDevice = null!;
+            BLEservice = null!;
+            U2FStatusChar = null!;
+        }
+
+        public string ConnectedDeviceName()
+        {
+            if (BLEservice == null) {
+                return string.Empty;
+            } else {
+                return BLEservice.Device.Name;
+            }
+        }
+
+        //
+        // BLE接続検知関連イベント
+        //
+        public delegate void HandlerOnConnectionStatusChanged(bool connected);
+        private event HandlerOnConnectionStatusChanged OnConnectionStatusChanged = null!;
+
+        private void BLEConnectionStatusChanged(BluetoothLEDevice sender, object args)
+        {
+            OnConnectionStatusChanged(sender.ConnectionStatus == BluetoothConnectionStatus.Connected);
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
+using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;
 
 namespace DesktopTool
@@ -57,7 +58,7 @@ namespace DesktopTool
             int retry = 3;
             for (int k = 0; k < retry + 1; k++) {
                 if (k > 0) {
-                    AppLogUtil.OutputLogWarn(string.Format(MSG_BLE_U2F_NOTIFICATION_RETRY, k));
+                    AppLogUtil.OutputLogDebug(string.Format(MSG_BLE_U2F_NOTIFICATION_RETRY, k));
                     await Task.Run(() => System.Threading.Thread.Sleep(100));
                 }
 
@@ -75,6 +76,7 @@ namespace DesktopTool
 
             // 接続されなかった場合は false
             AppLogUtil.OutputLogError(string.Format("{0}({1})", MSG_BLE_U2F_NOTIFICATION_FAILED, BLEservice.Device.Name));
+            FreeResources();
             return false;
         }
 
@@ -133,7 +135,9 @@ namespace DesktopTool
                 return true;
 
             } catch (Exception e) {
-                AppLogUtil.OutputLogError(string.Format("BLEService.StartBLENotification: {0}", e.Message));
+                if ((uint)e.HResult != WINDOWS_ERROR_NO_MORE_FILES) {
+                    AppLogUtil.OutputLogError(string.Format("BLEService.StartBLENotification: {0}", e.Message));
+                }
                 return false;
             }
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -52,7 +52,7 @@ namespace DesktopTool
             }
         }
 
-        public async Task<bool> StartCommunicate(BLEServiceParam parameter)
+        public async Task<bool> StartCommunicate(BLEServiceParam parameter, ConnectionStatusChangedHandler handler)
         {
             // Bluetoothアドレスが不正の場合は処理を実行しない
             if (parameter.BluetoothAddress == 0) {
@@ -65,6 +65,9 @@ namespace DesktopTool
                 FreeResources();
                 return false;
             }
+
+            // 接続検知時のコールバックを設定
+            ConnectionStatusChanged += handler;
 
             //
             // データ受信監視を開始
@@ -209,6 +212,9 @@ namespace DesktopTool
             BluetoothLEDevice = null!;
             BLEservice = null!;
             U2FStatusChar = null!;
+
+            // コールバック解除
+            ConnectionStatusChanged = null!;
         }
 
         public string ConnectedDeviceName()

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -33,7 +33,7 @@ namespace DesktopTool
         public BLEService()
         {
             // 応答タイムアウト発生時のイベントを登録
-            ResponseTimer = new CommonTimer("BLEService", 3000);
+            ResponseTimer = new CommonTimer("BLEService", U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC);
             ResponseTimer.CommandTimeoutEvent += OnResponseTimerElapsed;
             FreeResources();
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -204,10 +204,10 @@ namespace DesktopTool
         //
         // 送信処理
         // 
-        public async void Send(byte[] requestData)
+        public async void SendFrame(byte[] requestData)
         {
             if (BLEservice == null) {
-                AppLogUtil.OutputLogDebug(string.Format("BLEService.Send: service is null"));
+                AppLogUtil.OutputLogDebug(string.Format("BLEService.SendFrame: service is null"));
                 OnResponseReceived(false, MSG_REQUEST_SEND_FAILED, Array.Empty<byte>());
             }
 
@@ -230,7 +230,7 @@ namespace DesktopTool
                     }
 
                 } else {
-                    AppLogUtil.OutputLogDebug(string.Format("BLEService.Send: U2F control point characteristic is null"));
+                    AppLogUtil.OutputLogDebug(string.Format("BLEService.SendFrame: U2F control point characteristic is null"));
                     OnResponseReceived(false, MSG_REQUEST_SEND_FAILED, Array.Empty<byte>());
                 }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -53,7 +53,7 @@ namespace DesktopTool
         //
         // BLE接続検知関連イベント
         //
-        public delegate void ConnectionStatusChangedHandler(BLEService service, bool connected);
+        public delegate void ConnectionStatusChangedHandler(BLEService sender, bool connected);
         private event ConnectionStatusChangedHandler ConnectionStatusChanged = null!;
 
         private void BLEConnectionStatusChanged(BluetoothLEDevice sender, object args)
@@ -181,7 +181,7 @@ namespace DesktopTool
         //
         // 送受信関連イベント
         //
-        public delegate void ResponseReceivedHandler(BLEService service, bool success, string errorMessage, byte[] receivedData);
+        public delegate void ResponseReceivedHandler(BLEService sender, bool success, string errorMessage, byte[] receivedData);
         private event ResponseReceivedHandler ResponseReceived = null!;
 
         private void OnResponseReceived(bool success, string errorMessage, byte[] receivedData)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -184,24 +184,32 @@ namespace DesktopTool
         public delegate void ResponseReceivedHandler(BLEService sender, bool success, string errorMessage, byte[] receivedData);
         private event ResponseReceivedHandler ResponseReceived = null!;
 
+        public void RegisterResponseReceivedHandler(ResponseReceivedHandler handler)
+        {
+            // コールバックを設定
+            ResponseReceived += handler;
+        }
+
+        public void UnregisterResponseReceivedHandler(ResponseReceivedHandler handler)
+        {
+            // コールバック設定を解除
+            ResponseReceived -= handler;
+        }
+
         private void OnResponseReceived(bool success, string errorMessage, byte[] receivedData)
         {
             ResponseReceived?.Invoke(this, success, errorMessage, receivedData);
-            ResponseReceived = null!;
         }
 
         //
         // 送信処理
         // 
-        public async void Send(byte[] requestData, ResponseReceivedHandler handler)
+        public async void Send(byte[] requestData)
         {
             if (BLEservice == null) {
                 AppLogUtil.OutputLogDebug(string.Format("BLEService.Send: service is null"));
                 OnResponseReceived(false, MSG_REQUEST_SEND_FAILED, Array.Empty<byte>());
             }
-
-            // コールバックを設定
-            ResponseReceived += handler;
 
             try {
                 // リクエストデータを生成

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -36,6 +36,21 @@ namespace DesktopTool
 
         // ステータスを保持
         private GattCommunicationStatus CommunicationStatus;
+        //
+        // BLE接続検知関連イベント
+        //
+        public delegate void ConnectionStatusChangedHandler(BLEService service, bool connected);
+        private event ConnectionStatusChangedHandler ConnectionStatusChanged = null!;
+
+        private void BLEConnectionStatusChanged(BluetoothLEDevice sender, object args)
+        {
+            bool connected = (sender.ConnectionStatus == BluetoothConnectionStatus.Connected);
+            AppLogUtil.OutputLogDebug(string.Format("Connection status changed: BLE device is {0}", connected ? "connected" : "disconnected"));
+
+            if (ConnectionStatusChanged != null) {
+                ConnectionStatusChanged(this, connected);
+            }
+        }
 
         public async Task<bool> StartCommunicate(BLEServiceParam parameter)
         {
@@ -203,17 +218,6 @@ namespace DesktopTool
             } else {
                 return BLEservice.Device.Name;
             }
-        }
-
-        //
-        // BLE接続検知関連イベント
-        //
-        public delegate void HandlerOnConnectionStatusChanged(bool connected);
-        private event HandlerOnConnectionStatusChanged OnConnectionStatusChanged = null!;
-
-        private void BLEConnectionStatusChanged(BluetoothLEDevice sender, object args)
-        {
-            OnConnectionStatusChanged(sender.ConnectionStatus == BluetoothConnectionStatus.Connected);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -263,7 +263,7 @@ namespace DesktopTool
                 }
 
                 byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
-                if (responseCMD != 0x02) {
+                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD) == false) {
                     // キープアライブ以外の場合はログを出力
                     string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
                     AppLogUtil.OutputLogDebug(string.Format(
@@ -292,7 +292,7 @@ namespace DesktopTool
             if (ReceivedSize == ReceivedResponseLen) {
                 // CMDを抽出
                 byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
-                if (responseCMD == 0x02) {
+                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD)) {
                     // キープアライブの場合は引き続き次のレスポンスを待つ
                     return;
                 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -170,7 +170,7 @@ namespace DesktopTool
                 if (transferred == 0) {
                     // INITフレーム
                     // ヘッダーをコピー
-                    frameData[0] = requestCMD;
+                    frameData[0] = (byte)(0x80 | requestCMD);
                     frameData[1] = (byte)(transferBytesLen / 256);
                     frameData[2] = (byte)(transferBytesLen % 256);
 
@@ -262,7 +262,8 @@ namespace DesktopTool
                     ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_INIT_HEADER_LEN + i];
                 }
 
-                if (ReceivedResponse[0] != 0x82) {
+                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
+                if (responseCMD != 0x02) {
                     // キープアライブ以外の場合はログを出力
                     string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
                     AppLogUtil.OutputLogDebug(string.Format(
@@ -290,8 +291,8 @@ namespace DesktopTool
             // 全フレームがそろった場合
             if (ReceivedSize == ReceivedResponseLen) {
                 // CMDを抽出
-                byte responseCMD = ReceivedResponse[0];
-                if (responseCMD == 0x82) {
+                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
+                if (responseCMD == 0x02) {
                     // キープアライブの場合は引き続き次のレスポンスを待つ
                     return;
                 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -1,0 +1,100 @@
+﻿using AppCommon;
+using static DesktopTool.HelperMessage;
+
+namespace DesktopTool
+{
+    internal class BLETransport
+    {
+        // ヘルパークラスの参照を保持
+        private BLEService BLEServiceRef = null!;
+
+        //
+        // 接続処理
+        //
+        public delegate void NotifyConnectionHandler(BLETransport sender, bool success, string errorMessage);
+        private event NotifyConnectionHandler NotifyConnection = null!;
+
+        public void Connect(NotifyConnectionHandler notifyConnectionHandler)
+        {
+            // コールバックを設定
+            NotifyConnection += notifyConnectionHandler;
+
+            // BLEデバイスをスキャン
+            BLEPeripheralScannerParam parameter = BLEPeripheralScannerParam.PrepareParameterForFIDO();
+            new BLEPeripheralScanner().DoProcess(parameter, OnBLEPeripheralScanned);
+        }
+
+        private void OnNotifyConnectionSuccess(BLEService serviceRef)
+        {
+            // ヘルパークラスの参照を保持
+            BLEServiceRef = serviceRef;
+            
+            // コールバックを実行
+            NotifyConnection?.Invoke(this, true, string.Empty);
+            NotifyConnection = null!;
+        }
+
+        private void OnNotifyConnectionFailure(string errorMessage)
+        {
+            // ヘルパークラスの参照をクリア
+            BLEServiceRef = null!;
+
+            // コールバックを実行
+            NotifyConnection?.Invoke(this, false, errorMessage);
+            NotifyConnection = null!;
+        }
+
+        private async void OnBLEPeripheralScanned(bool success, string errorMessage, BLEPeripheralScannerParam parameter)
+        {
+            if (success == false) {
+                // 失敗時はログ出力
+                OnNotifyConnectionFailure(errorMessage);
+                return;
+            }
+
+            if (parameter.FIDOServiceDataFieldFound) {
+                // ペアリングモード時（＝サービスデータフィールドが存在する場合）はエラー扱い
+                OnNotifyConnectionFailure(MSG_ERROR_FUNCTION_IN_PAIRING_MODE);
+                return;
+            }
+
+            // 成功時はログ出力
+            AppLogUtil.OutputLogInfo(MSG_SCAN_BLE_DEVICE_SUCCESS);
+
+            // サービスに接続
+            BLEServiceParam serviceParam = new BLEServiceParam(parameter);
+            BLEService service = new BLEService();
+            await service.StartCommunicate(serviceParam, OnConnectionStatusChanged);
+
+            if (service.IsConnected()) {
+                // 接続成功の場合
+                AppLogUtil.OutputLogInfo(MSG_CONNECT_BLE_DEVICE_SUCCESS);
+                OnNotifyConnectionSuccess(service);
+
+            } else {
+                // 接続失敗の場合は処理終了
+                OnNotifyConnectionFailure(MSG_CONNECT_BLE_DEVICE_FAILURE);
+            }
+        }
+
+        private void OnConnectionStatusChanged(BLEService service, bool connected)
+        {
+            if (connected == false) {
+                // 切断検知時は、接続を終了させる
+                service.Disconnect();
+                AppLogUtil.OutputLogInfo(MSG_NOTIFY_DISCONNECT_BLE_DEVICE);
+            }
+        }
+
+        //
+        // 切断処理
+        //
+        public void Disconnect()
+        {
+            if (BLEServiceRef != null) {
+                BLEServiceRef.Disconnect();
+                AppLogUtil.OutputLogInfo(MSG_DISCONNECT_BLE_DEVICE);
+            }
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -1,4 +1,7 @@
 ﻿using AppCommon;
+using System;
+using System.Linq;
+using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;
 
 namespace DesktopTool
@@ -94,6 +97,213 @@ namespace DesktopTool
             if (BLEServiceRef != null) {
                 BLEServiceRef.Disconnect();
                 AppLogUtil.OutputLogInfo(MSG_DISCONNECT_BLE_DEVICE);
+            }
+        }
+
+        //
+        // 送受信関連イベント
+        //
+        public delegate void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes);
+        private event ResponseReceivedHandler ResponseReceived = null!;
+
+        public void RegisterResponseReceivedHandler(ResponseReceivedHandler handler)
+        {
+            // コールバックを設定
+            ResponseReceived += handler;
+        }
+
+        public void UnregisterResponseReceivedHandler(ResponseReceivedHandler handler)
+        {
+            // コールバック設定を解除
+            ResponseReceived -= handler;
+        }
+
+        private void OnResponseReceived(bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
+        {
+            // コールバック設定を解除
+            BLEServiceRef.UnregisterFrameReceivedHandler(FrameReceivedHandler);
+
+            // このクラスのコールバックを実行
+            ResponseReceived?.Invoke(this, success, errorMessage, responseCMD, responseBytes);
+        }
+
+        //
+        // 送信処理
+        //
+        public void SendRequest(byte requestCMD, byte[] requestBytes)
+        {
+            // コールバックを設定
+            BLEServiceRef.RegisterFrameReceivedHandler(FrameReceivedHandler);
+
+            // APDUの長さを取得
+            int transferBytesLen = requestBytes.Length;
+            if (transferBytesLen == 0) {
+                // データ長０のフレームを送信
+                byte[] frame = new byte[] { requestCMD, 0, 0 };
+                BLEServiceRef.SendFrame(frame);
+                AppLogUtil.OutputLogDebug("BLE Sent INIT frame: data size=0");
+                return;
+            }
+
+            // 
+            // 送信データをフレーム分割
+            // 
+            //  INITフレーム
+            //  1     バイト目: コマンド
+            //  2 - 3 バイト目: データ長
+            //  残りのバイト  : データ部（64 - 3 = 61）
+            //
+            //  CONTフレーム
+            //  1     バイト目: シーケンス
+            //  残りのバイト  : データ部（64 - 1 = 63）
+            // 
+            byte[] frameData = new byte[U2F_BLE_FRAME_LEN];
+            int transferred = 0;
+            int seq = 0;
+            while (transferred < transferBytesLen) {
+                for (int j = 0; j < frameData.Length; j++) {
+                    // フレームデータを初期化
+                    frameData[j] = 0;
+                }
+
+                int frameLen;
+                if (transferred == 0) {
+                    // INITフレーム
+                    // ヘッダーをコピー
+                    frameData[0] = requestCMD;
+                    frameData[1] = (byte)(transferBytesLen / 256);
+                    frameData[2] = (byte)(transferBytesLen % 256);
+
+                    // データをコピー
+                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
+                    int dataLenInFrame = (transferBytesLen < maxLen) ? transferBytesLen : maxLen;
+                    for (int i = 0; i < dataLenInFrame; i++) {
+                        frameData[U2F_BLE_INIT_HEADER_LEN + i] = requestBytes[transferred++];
+                    }
+
+                    // フレーム長を取得
+                    frameLen = U2F_BLE_INIT_HEADER_LEN + dataLenInFrame;
+
+                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
+                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent INIT frame: data size={0} length={1}\r\n{2}",
+                        transferBytesLen, dataLenInFrame, dump));
+
+                } else {
+                    // CONTフレーム
+                    // ヘッダーをコピー
+                    frameData[0] = (byte)seq;
+
+                    // データをコピー
+                    int remaining = transferBytesLen - transferred;
+                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
+                    int dataLenInFrame = (remaining < maxLen) ? remaining : maxLen;
+                    for (int i = 0; i < dataLenInFrame; i++) {
+                        frameData[U2F_BLE_CONT_HEADER_LEN + i] = requestBytes[transferred++];
+                    }
+
+                    // フレーム長を取得
+                    frameLen = U2F_BLE_CONT_HEADER_LEN + dataLenInFrame;
+
+                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
+                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent CONT frame: data seq={0} length={1}\r\n{2}",
+                        seq++, dataLenInFrame, dump));
+                }
+
+                // BLEデバイスにフレームを送信
+                BLEServiceRef.SendFrame(frameData.Take(frameLen).ToArray());
+            }
+        }
+
+        //
+        // 受信処理（コールバック）
+        //
+        private byte[] ReceivedResponse = Array.Empty<byte>();
+        private int ReceivedResponseLen = 0;
+        private int ReceivedSize = 0;
+
+        private void FrameReceivedHandler(BLEService service, bool success, string errorMessage, byte[] frameBytes)
+        {
+            if (success == false) {
+                OnResponseReceived(success, errorMessage, 0x00, Array.Empty<byte>());
+                return;
+            }
+
+            // 
+            // 受信したデータをバッファにコピー
+            // 
+            //  INITフレーム
+            //  1     バイト目: コマンド
+            //  2 - 3 バイト目: データ長
+            //  残りのバイト  : データ部（64 - 3 = 61）
+            //
+            //  CONTフレーム
+            //  1     バイト目: シーケンス
+            //  残りのバイト  : データ部（64 - 1 = 63）
+            // 
+            int bleInitDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
+            int bleContDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
+            byte cmd = frameBytes[0];
+            if (cmd > 127) {
+                // INITフレームであると判断
+                byte cnth = frameBytes[1];
+                byte cntl = frameBytes[2];
+                ReceivedResponseLen = cnth * 256 + cntl;
+                ReceivedResponse = new byte[U2F_BLE_INIT_HEADER_LEN + ReceivedResponseLen];
+                ReceivedSize = 0;
+
+                // ヘッダーをコピー
+                for (int i = 0; i < U2F_BLE_INIT_HEADER_LEN; i++) {
+                    ReceivedResponse[i] = frameBytes[i];
+                }
+
+                // データをコピー
+                int dataLenInFrame = (ReceivedResponseLen < bleInitDataLen) ? ReceivedResponseLen : bleInitDataLen;
+                for (int i = 0; i < dataLenInFrame; i++) {
+                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_INIT_HEADER_LEN + i];
+                }
+
+                if (ReceivedResponse[0] != 0x82) {
+                    // キープアライブ以外の場合はログを出力
+                    string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+                    AppLogUtil.OutputLogDebug(string.Format(
+                        "BLE Recv INIT frame: data size={0} length={1}\r\n{2}",
+                        ReceivedResponseLen, dataLenInFrame, dump));
+                }
+
+            } else {
+                // CONTフレームであると判断
+                int seq = frameBytes[0];
+
+                // データをコピー
+                int remaining = ReceivedResponseLen - ReceivedSize;
+                int dataLenInFrame = (remaining < bleContDataLen) ? remaining : bleContDataLen;
+                for (int i = 0; i < dataLenInFrame; i++) {
+                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_CONT_HEADER_LEN + i];
+                }
+
+                string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+                AppLogUtil.OutputLogDebug(string.Format(
+                    "BLE Recv CONT frame: seq={0} length={1}\r\n{2}",
+                    seq, dataLenInFrame, dump));
+            }
+
+            // 全フレームがそろった場合
+            if (ReceivedSize == ReceivedResponseLen) {
+                // CMDを抽出
+                byte responseCMD = ReceivedResponse[0];
+                if (responseCMD == 0x82) {
+                    // キープアライブの場合は引き続き次のレスポンスを待つ
+                    return;
+                }
+
+                // 受信データを転送
+                if (ReceivedResponseLen == 0) {
+                    OnResponseReceived(true, string.Empty, responseCMD, Array.Empty<byte>());
+
+                } else {
+                    byte[] response = ReceivedResponse.Skip(U2F_BLE_INIT_HEADER_LEN).ToArray();
+                    OnResponseReceived(true, string.Empty, responseCMD, response);
+                }
             }
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -77,11 +77,11 @@ namespace DesktopTool
             }
         }
 
-        private void OnConnectionStatusChanged(BLEService service, bool connected)
+        private void OnConnectionStatusChanged(BLEService sender, bool connected)
         {
             if (connected == false) {
                 // 切断検知時は、接続を終了させる
-                service.Disconnect();
+                sender.Disconnect();
                 AppLogUtil.OutputLogInfo(MSG_NOTIFY_DISCONNECT_BLE_DEVICE);
             }
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -10,5 +10,14 @@
         public const string MSG_BLE_PARING_ERR_PROCESS = "BLEデバイスとのペアリング時にエラーが発生しました。";
         public const string MSG_BLE_PARING_ERR_UNKNOWN = "BLEデバイスとのペアリング時に不明なエラーが発生しました。";
         public const string MSG_BLE_PARING_ERR_CANCELED_BY_USER = "BLEデバイスとのペアリング実行をユーザーが中止しました。";
+
+        // BLEサービス
+        public const string MSG_BLE_U2F_NOTIFICATION_RETRY = "受信データ監視開始を再試行しています（{0}回目）";
+        public const string MSG_BLE_U2F_NOTIFICATION_START = "受信データの監視を開始します。";
+        public const string MSG_BLE_U2F_NOTIFICATION_FAILED = "BLEサービスからデータを受信できません。";
+        public const string MSG_BLE_U2F_SERVICE_FINDING = "BLEサービス({0})を検索します。";
+        public const string MSG_BLE_U2F_DEVICE_NOT_FOUND = "BLEサービスが動作するデバイスが見つかりません。";
+        public const string MSG_BLE_U2F_SERVICE_NOT_FOUND = "BLEサービスが見つかりません。";
+        public const string MSG_BLE_U2F_SERVICE_FOUND = "BLEサービスが見つかりました。";
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -19,5 +19,11 @@
         public const string MSG_BLE_U2F_DEVICE_NOT_FOUND = "BLEサービスが動作するデバイスが見つかりません。";
         public const string MSG_BLE_U2F_SERVICE_NOT_FOUND = "BLEサービスが見つかりません。";
         public const string MSG_BLE_U2F_SERVICE_FOUND = "BLEサービスが見つかりました。";
+
+        // トランスポート共通
+        public const string MSG_REQUEST_SEND_FAILED = "リクエスト送信が失敗しました。";
+        public const string MSG_REQUEST_SEND_FAILED_WITH_EXCEPTION = "リクエスト送信が失敗しました：{0}";
+        public const string MSG_REQUEST_SEND_TIMED_OUT = "リクエスト送信がタイムアウトしました。";
+        public const string MSG_RESPONSE_RECEIVE_FAILED_WITH_EXCEPTION = "レスポンス受信が失敗しました：{0}";
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/HelperMessage.cs
@@ -25,5 +25,13 @@
         public const string MSG_REQUEST_SEND_FAILED_WITH_EXCEPTION = "リクエスト送信が失敗しました：{0}";
         public const string MSG_REQUEST_SEND_TIMED_OUT = "リクエスト送信がタイムアウトしました。";
         public const string MSG_RESPONSE_RECEIVE_FAILED_WITH_EXCEPTION = "レスポンス受信が失敗しました：{0}";
+
+        // コマンド共通
+        public const string MSG_ERROR_FUNCTION_IN_PAIRING_MODE = "ペアリングモードでは、ペアリング実行以外の機能は使用できません。ペアリングモードを解除してから、機能を再度実行してください。";
+        public const string MSG_SCAN_BLE_DEVICE_SUCCESS = "対象のBLEデバイスがスキャンされました。";
+        public const string MSG_CONNECT_BLE_DEVICE_FAILURE = "BLEデバイスの接続に失敗しました。";
+        public const string MSG_CONNECT_BLE_DEVICE_SUCCESS = "BLEデバイスに接続しました。";
+        public const string MSG_NOTIFY_DISCONNECT_BLE_DEVICE = "BLEデバイスからの切断を検知しました。接続を終了します。";
+        public const string MSG_DISCONNECT_BLE_DEVICE = "BLEデバイスから切断しました。";
     }
 }

--- a/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
+++ b/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>VendorTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).003</FileVersion>
+    <FileVersion>$(Version).005</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
[nRF5340ファームウェア](https://github.com/makmorit/SquareDevices/tree/main/nRF5340FW/square_devices_app)の管理機能を利用し、nRF5340基板上からペアリング情報を削除する機能を実装します。