### PR TITLE
[Windows版ツール対応] BLEペアリング解除要求機能の実装

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).006</FileVersion>
+    <FileVersion>$(Version).007</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
@@ -61,6 +61,10 @@ namespace DesktopTool
             string deviceName = Instance.Parameter.ConnectedDeviceName;
             string message = string.Format(MSG_BLE_UNPAIRING_WAIT_DISCONNECT, deviceName);
             model.ShowTitle(message);
+
+            // TODO: 仮の実装です。
+            message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, 30);
+            model.ShowRemaining(message);
         }
 
         public static void OnCancel(BLEUnpairRequestViewModel model)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
@@ -15,6 +15,9 @@ namespace DesktopTool
 
     internal class BLEUnpairRequest
     {
+        // Bluetooth環境設定からデバイスが削除されるのを待機する時間（秒）
+        public const int UNPAIRING_REQUEST_WAITING_SEC = 30;
+
         // このクラスのインスタンス
         public static BLEUnpairRequest Instance = null!;
         private BLEUnpairRequestWindow Window = null!;
@@ -58,22 +61,34 @@ namespace DesktopTool
         //
         public static void InitView(BLEUnpairRequestViewModel model)
         {
+            // 接続中のデバイス名称を画面表示
             string deviceName = Instance.Parameter.ConnectedDeviceName;
             string message = string.Format(MSG_BLE_UNPAIRING_WAIT_DISCONNECT, deviceName);
             model.ShowTitle(message);
 
-            // TODO: 仮の実装です。
-            int level = 30;
-            message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, level);
-            model.ShowRemaining(message);
+            // 最大待機秒数を設定
+            int level = UNPAIRING_REQUEST_WAITING_SEC;
             model.SetMaxLevel(level);
-            model.SetLevel(level);
+
+            // 残り秒数を画面表示
+            NotifyProgress(model, level);
         }
 
         public static void OnCancel(BLEUnpairRequestViewModel model)
         {
             // 画面を閉じる
             Instance.NotifyTerminateInner(false);
+        }
+
+        //
+        // 内部処理
+        //
+        private static void NotifyProgress(BLEUnpairRequestViewModel model, int remaining)
+        {
+            // 残り秒数をペアリング解除待機画面に表示
+            string message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, remaining);
+            model.ShowRemaining(message);
+            model.SetLevel(remaining);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
@@ -39,6 +39,12 @@ namespace DesktopTool
             }
         }
 
+        public void CloseForm(bool dialogResult)
+        {
+            // 画面を閉じる
+            NotifyTerminateInner(dialogResult);
+        }
+
         private void NotifyTerminateInner(bool b)
         {
             // この画面を閉じる

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
 using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
@@ -6,10 +9,16 @@ namespace DesktopTool
     internal class BLEUnpairRequestParam
     {
         public string ConnectedDeviceName { get; set; }
+        public string ErrorMessage { get; set; }
+
+        // タイムアウト監視フラグ
+        public bool WaitingForUnpairTimeout { get; set; }
 
         public BLEUnpairRequestParam(string connectedDeviceName)
         {
             ConnectedDeviceName = connectedDeviceName;
+            ErrorMessage = string.Empty;
+            WaitingForUnpairTimeout = false;
         }
     }
 
@@ -45,11 +54,14 @@ namespace DesktopTool
         public void CloseForm(bool dialogResult)
         {
             // 画面を閉じる
-            NotifyTerminateInner(dialogResult);
+            NotifyTerminateInner(dialogResult, string.Empty);
         }
 
-        private void NotifyTerminateInner(bool b)
+        private void NotifyTerminateInner(bool b, string errorMessage)
         {
+            // エラーメッセージを設定
+            Parameter.ErrorMessage = errorMessage;
+
             // この画面を閉じる
             Window.DialogResult = b;
             Window.Close();
@@ -72,12 +84,17 @@ namespace DesktopTool
 
             // 残り秒数を画面表示
             NotifyProgress(model, level);
+
+            // タイムアウト監視を開始
+            Task task = Task.Run(() => {
+                Instance.StartWaitingForUnpairTimeoutMonitor(model);
+            });
         }
 
         public static void OnCancel(BLEUnpairRequestViewModel model)
         {
-            // 画面を閉じる
-            Instance.NotifyTerminateInner(false);
+            // タイムアウト監視を中止
+            Instance.StopWaitingForUnpairTimeoutMonitor();
         }
 
         //
@@ -89,6 +106,51 @@ namespace DesktopTool
             string message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, remaining);
             model.ShowRemaining(message);
             model.SetLevel(remaining);
+        }
+
+        //
+        // ペアリング解除要求からペアリング解除による切断検知までの
+        // タイムアウト監視
+        //
+        private void StartWaitingForUnpairTimeoutMonitor(BLEUnpairRequestViewModel model)
+        {
+            // タイムアウト監視を開始
+            Parameter.WaitingForUnpairTimeout = true;
+
+            // タイムアウト監視（最大30秒）
+            for (int i = 0; i < UNPAIRING_REQUEST_WAITING_SEC; i++) {
+                // 残り秒数をペアリング解除要求画面に通知
+                Application.Current.Dispatcher.Invoke(new Action(() => {
+                    // 残り秒数を画面表示
+                    NotifyProgress(model, UNPAIRING_REQUEST_WAITING_SEC - i);
+                }));
+
+                for (int j = 0; j < 5; j++) {
+                    // タイムアウト監視停止指示の有無を、0.2秒ごとにチェック
+                    if (Parameter.WaitingForUnpairTimeout == false) {
+                        // ユーザーにより中止ボタンがクリックされた場合は監視中止
+                        return;
+                    }
+                    Thread.Sleep(200);
+                }
+            }
+
+            Application.Current.Dispatcher.Invoke(new Action(() => {
+                // 残り秒数を画面表示
+                NotifyProgress(model, 0);
+
+                // エラーメッセージを設定し、画面を閉じる
+                NotifyTerminateInner(false, MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT);
+            }));
+        }
+
+        private void StopWaitingForUnpairTimeoutMonitor()
+        {
+            // タイムアウト監視を中止
+            Parameter.WaitingForUnpairTimeout = false;
+
+            // エラーメッセージを設定し、画面を閉じる
+            NotifyTerminateInner(false, MSG_BLE_UNPAIRING_WAIT_CANCELED);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequest.cs
@@ -63,8 +63,11 @@ namespace DesktopTool
             model.ShowTitle(message);
 
             // TODO: 仮の実装です。
-            message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, 30);
+            int level = 30;
+            message = string.Format(MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT, level);
             model.ShowRemaining(message);
+            model.SetMaxLevel(level);
+            model.SetLevel(level);
         }
 
         public static void OnCancel(BLEUnpairRequestViewModel model)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestViewModel.cs
@@ -8,12 +8,16 @@ namespace DesktopTool
         private readonly RelayCommand ButtonCloseClickedRelayCommand;
         private string title = null!;
         private string remaining = null!;
+        private int level = 0;
+        private int maxLevel = 0;
 
         public BLEUnpairRequestViewModel()
         {
             ButtonCloseClickedRelayCommand = new RelayCommand(OnButtonCloseClicked);
             Title = string.Empty;
             Remaining = string.Empty;
+            Level = 0;
+            MaxLevel = 100;
             try { BLEUnpairRequest.InitView(this); } catch { }
         }
 
@@ -32,6 +36,18 @@ namespace DesktopTool
         {
             get { return remaining; }
             set { remaining = value; NotifyPropertyChanged(nameof(Remaining)); }
+        }
+
+        public int Level
+        {
+            get { return level; }
+            set { level = value; NotifyPropertyChanged(nameof(Level)); }
+        }
+
+        public int MaxLevel
+        {
+            get { return maxLevel; }
+            set { maxLevel = value; NotifyPropertyChanged(nameof(MaxLevel)); }
         }
 
         //
@@ -53,6 +69,16 @@ namespace DesktopTool
         public void ShowRemaining(string text)
         {
             Remaining = text;
+        }
+
+        public void SetLevel(int value)
+        {
+            Level = value;
+        }
+
+        public void SetMaxLevel(int value)
+        {
+            MaxLevel = value;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestViewModel.cs
@@ -7,11 +7,13 @@ namespace DesktopTool
     {
         private readonly RelayCommand ButtonCloseClickedRelayCommand;
         private string title = null!;
+        private string remaining = null!;
 
         public BLEUnpairRequestViewModel()
         {
             ButtonCloseClickedRelayCommand = new RelayCommand(OnButtonCloseClicked);
             Title = string.Empty;
+            Remaining = string.Empty;
             try { BLEUnpairRequest.InitView(this); } catch { }
         }
 
@@ -24,6 +26,12 @@ namespace DesktopTool
         {
             get { return title; }
             set { title = value; NotifyPropertyChanged(nameof(Title)); }
+        }
+
+        public string Remaining
+        {
+            get { return remaining; }
+            set { remaining = value; NotifyPropertyChanged(nameof(Remaining)); }
         }
 
         //
@@ -40,6 +48,11 @@ namespace DesktopTool
         public void ShowTitle(string text)
         {
             Title = text;
+        }
+
+        public void ShowRemaining(string text)
+        {
+            Remaining = text;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestWindow.xaml
@@ -12,7 +12,7 @@
     <Grid Height="220">
         <Label x:Name="labelTitle" Content="{Binding Title}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="0,10,0,0" Width="350" Height="70"/>
         <ProgressBar x:Name="levelIndicator" HorizontalAlignment="Center" Height="24" VerticalAlignment="Top" Width="350" Margin="0,90,0,0"/>
-        <Label x:Name="labelProgress" Content="" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="0,130,0,0" Width="350"/>
+        <Label x:Name="labelRemaining" Content="{Binding Remaining}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="0,130,0,0" Width="350"/>
         <Button x:Name="buttonClose" Content="中止" Command="{Binding ButtonCloseClicked}" HorizontalAlignment="Center" Margin="0,175,0,0" VerticalAlignment="Top" Height="25" Width="150"/>
     </Grid>
 </Window>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairRequestWindow.xaml
@@ -11,7 +11,7 @@
     </Window.DataContext>
     <Grid Height="220">
         <Label x:Name="labelTitle" Content="{Binding Title}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="0,10,0,0" Width="350" Height="70"/>
-        <ProgressBar x:Name="levelIndicator" HorizontalAlignment="Center" Height="24" VerticalAlignment="Top" Width="350" Margin="0,90,0,0"/>
+        <ProgressBar x:Name="levelIndicator" Value="{Binding Level}" Maximum="{Binding MaxLevel}" HorizontalAlignment="Center" Height="24" VerticalAlignment="Top" Width="350" Margin="0,90,0,0"/>
         <Label x:Name="labelRemaining" Content="{Binding Remaining}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="0,130,0,0" Width="350"/>
         <Button x:Name="buttonClose" Content="中止" Command="{Binding ButtonCloseClicked}" HorizontalAlignment="Center" Margin="0,175,0,0" VerticalAlignment="Top" Height="25" Width="150"/>
     </Grid>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -54,10 +54,28 @@ namespace DesktopTool
         private void OnResponseCancelCommand(BLETransport sender, byte[] responseBytes)
         {
             // ペアリング解除要求キャンセルが完了
-            TerminateCommand(sender, true, string.Empty);
+            CancelCommand(sender, true, string.Empty);
+        }
+
+        private void CancelCommand(BLETransport sender, bool success, string errorMessage)
+        {
+            // 終了処理を実行
+            Terminate(sender, success, errorMessage);
+
+            // 後続処理を実行
+            CancelProcess();
         }
 
         private void TerminateCommand(BLETransport sender, bool success, string errorMessage)
+        {
+            // 終了処理を実行
+            Terminate(sender, success, errorMessage);
+
+            // 後続処理を実行
+            ResumeProcess(success);
+        }
+
+        private void Terminate(BLETransport sender, bool success, string errorMessage)
         {
             // コールバックを解除
             sender.UnregisterResponseReceivedHandler(ResponseReceivedHandler);
@@ -70,9 +88,6 @@ namespace DesktopTool
                 // 失敗時はログ出力
                 LogAndShowErrorMessage(errorMessage);
             }
-
-            // 後続処理を実行
-            ResumeProcess(success);
         }
 
         //
@@ -165,6 +180,9 @@ namespace DesktopTool
                 // ペアリング解除が完了
                 TerminateCommand(sender, true, string.Empty);
             }
+
+            // ペアリング解除待機処理クラスの参照をクリア
+            UnpairRequest = null!;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AppCommon;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -30,6 +31,7 @@ namespace DesktopTool
 
             // コールバックを登録
             sender.RegisterResponseReceivedHandler(ResponseReceivedHandler);
+            sender.RegisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler);
 
             // ペアリング解除要求コマンド（１回目）を実行
             PerformInquiryCommand(sender);
@@ -57,6 +59,10 @@ namespace DesktopTool
 
         private void TerminateCommand(BLETransport sender, bool success, string errorMessage)
         {
+            // コールバックを解除
+            sender.UnregisterResponseReceivedHandler(ResponseReceivedHandler);
+            sender.UnregisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler);
+
             // 接続を終了
             sender.Disconnect();
 
@@ -122,6 +128,14 @@ namespace DesktopTool
 
             } else {
                 OnResponseCancelCommand(sender, responseBytes);
+            }
+        }
+
+        private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
+        {
+            if (connected == false) {
+                // TODO: 仮の実装です。
+                AppLogUtil.OutputLogError("BLEUnpairing.NotifyConnectionStatusHandler: BLE disconnected");
             }
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -134,17 +134,26 @@ namespace DesktopTool
         private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
         {
             if (connected == false) {
+                if (UnpairRequest == null) {
+                    // ペアリング解除待機前に接続断が検知された場合はエラー扱い
+                    TerminateCommand(sender, false, MSG_BLE_UNPAIRING_DISCONN_BEFORE_PROC);
+                    return;
+                }
+
                 // TODO: 仮の実装です。
                 AppLogUtil.OutputLogError("BLEUnpairing.NotifyConnectionStatusHandler: BLE disconnected");
             }
         }
 
+        // ペアリング解除待機処理クラスの参照を保持
+        BLEUnpairRequest UnpairRequest = null!;
+
         private void ShowUnpairingRequestWindow(BLETransport sender)
         {
             // ペアリング解除待機画面を表示
             BLEUnpairRequestParam parameter = new BLEUnpairRequestParam(sender.ConnectedDeviceName());
-            BLEUnpairRequest unpairRequest = new BLEUnpairRequest(parameter);
-            if (unpairRequest.OpenForm() == false) {
+            UnpairRequest = new BLEUnpairRequest(parameter);
+            if (UnpairRequest.OpenForm() == false) {
                 // ペアリング解除要求をキャンセル
                 PerformCancelCommand(sender);
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -174,6 +174,9 @@ namespace DesktopTool
             // ペアリング解除待機画面を表示
             UnpairRequest = new BLEUnpairRequest(parameter);
             if (UnpairRequest.OpenForm() == false) {
+                // キャンセル事由をログ出力
+                LogAndShowInfoMessage(parameter.ErrorMessage);
+
                 // ペアリング解除要求をキャンセル
                 PerformCancelCommand(sender);
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -1,5 +1,4 @@
-﻿using AppCommon;
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -157,8 +156,10 @@ namespace DesktopTool
                     return;
                 }
 
-                // TODO: 仮の実装です。
-                AppLogUtil.OutputLogError("BLEUnpairing.NotifyConnectionStatusHandler: BLE disconnected");
+                // ペアリング解除待機画面を閉じる
+                Application.Current.Dispatcher.Invoke(new Action(() => {
+                    UnpairRequest.CloseForm(true);
+                }));
             }
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -109,11 +109,13 @@ namespace DesktopTool
 
         private void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
         {
+            // レスポンス受信失敗時はエラー扱い
             if (success == false) {
                 TerminateCommand(sender, false, errorMessage);
                 return;
             }
 
+            // レスポンスステータスをチェック
             byte status = responseBytes[0];
             if (status != CTAP1_ERR_SUCCESS) {
                 TerminateCommand(sender, false, string.Format(MSG_FORMAT_OCCUR_UNKNOWN_ERROR_ST, status));
@@ -150,8 +152,10 @@ namespace DesktopTool
 
         private void ShowUnpairingRequestWindow(BLETransport sender)
         {
-            // ペアリング解除待機画面を表示
+            // 現在接続中のデバイス名称をパラメーターに設定
             BLEUnpairRequestParam parameter = new BLEUnpairRequestParam(sender.ConnectedDeviceName());
+
+            // ペアリング解除待機画面を表示
             UnpairRequest = new BLEUnpairRequest(parameter);
             if (UnpairRequest.OpenForm() == false) {
                 // ペアリング解除要求をキャンセル

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -2,12 +2,27 @@
 using System.Threading.Tasks;
 using static DesktopTool.FunctionMessage;
 using static DesktopTool.FunctionDefines;
+using System.Windows;
 
 namespace DesktopTool
 {
     internal class EraseBondingInfo : ToolDoProcess
     {
         public EraseBondingInfo(string menuItemName) : base(menuItemName) { }
+
+        protected override void ShowPromptForStartProcess(ToolDoProcessViewModel model)
+        {
+            // 確認メッセージを表示し、Yesの場合だけ処理を続行する
+            Window parentWindow = Application.Current.MainWindow;
+            string message = string.Format("{0}\n\n{1}", MSG_BLE_ERASE_BONDS, MSG_PROMPT_BLE_ERASE_BONDS);
+            if (DialogUtil.DisplayPromptPopup(parentWindow, MenuItemName, message) == false) {
+                return;
+            }
+
+            // 後続処理を実行
+            base.ShowPromptForStartProcess(model);
+        }
+
 
         protected override void InvokeProcessOnSubThread()
         {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -37,6 +37,8 @@
         public const string MSG_BLE_UNPAIRING_DISCONN_BEFORE_PROC = "ペアリング解除要求中に、BLEデバイスからの切断が検知されました。";
         public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」が\n削除されるのを待機しています。";
         public const string MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT = "あと {0} 秒";
+        public const string MSG_BLE_UNPAIRING_WAIT_CANCELED = "ユーザーがペアリング解除を中止しました。";
+        public const string MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT = "Bluetooth環境設定からのデバイス削除が検知されませんでした。ペアリング解除要求を中止します。";
 
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -36,6 +36,7 @@
         // ペアリング解除要求
         public const string MSG_BLE_UNPAIRING_DISCONN_BEFORE_PROC = "ペアリング解除要求中に、BLEデバイスからの切断が検知されました。";
         public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」が\n削除されるのを待機しています。";
+        public const string MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT = "あと {0} 秒";
 
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -38,7 +38,7 @@
         public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」が\n削除されるのを待機しています。";
         public const string MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT = "あと {0} 秒";
         public const string MSG_BLE_UNPAIRING_WAIT_CANCELED = "ユーザーがペアリング解除を中止しました。";
-        public const string MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT = "Bluetooth環境設定からのデバイス削除が検知されませんでした。ペアリング解除要求を中止します。";
+        public const string MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT = "Bluetooth環境設定からのデバイス削除が検知されませんでした。";
 
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -35,9 +35,9 @@
 
         // ペアリング解除要求
         public const string MSG_BLE_UNPAIRING_DISCONN_BEFORE_PROC = "ペアリング解除要求中に、BLEデバイスからの切断が検知されました。";
-        public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」が\n削除されるのを待機しています。";
+        public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」を削除すると、\nデバイスとのペアリングが解除されます。";
         public const string MSG_BLE_UNPAIRING_WAIT_SEC_FORMAT = "あと {0} 秒";
-        public const string MSG_BLE_UNPAIRING_WAIT_CANCELED = "ユーザーがペアリング解除を中止しました。";
+        public const string MSG_BLE_UNPAIRING_WAIT_CANCELED = "BLEデバイスのペアリング解除をユーザーが中止しました。";
         public const string MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT = "Bluetooth環境設定からのデバイス削除が検知されませんでした。";
 
         // デバイス情報参照画面

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -40,6 +40,10 @@
         public const string MSG_BLE_UNPAIRING_WAIT_CANCELED = "BLEデバイスのペアリング解除をユーザーが中止しました。";
         public const string MSG_BLE_UNPAIRING_WAIT_DISC_TIMEOUT = "Bluetooth環境設定からのデバイス削除が検知されませんでした。";
 
+        // ペアリング情報削除
+        public const string MSG_BLE_ERASE_BONDS = "BLEデバイスからペアリング情報をすべて削除します。";
+        public const string MSG_PROMPT_BLE_ERASE_BONDS = "削除後は全てのPC等から、BLEデバイスに接続できなくなります。\n削除処理を実行しますか？";
+
         // デバイス情報参照画面
         public const string MSG_DEVICE_FW_VERSION_INFO_SHOWING = "デバイスに導入されているファームウェア等に関する情報を表示しています。";
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -34,6 +34,7 @@
         public const string MSG_PROMPT_INPUT_PAIRING_PASSCODE_NUM = "パスコードを数字で入力してください";
 
         // ペアリング解除要求
+        public const string MSG_BLE_UNPAIRING_DISCONN_BEFORE_PROC = "ペアリング解除要求中に、BLEデバイスからの切断が検知されました。";
         public const string MSG_BLE_UNPAIRING_WAIT_DISCONNECT = "Bluetooth環境設定から\nデバイス「{0}」が\n削除されるのを待機しています。";
 
         // デバイス情報参照画面

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -35,7 +35,8 @@ namespace DesktopTool
 
         public static void StartProcess(ToolDoProcessViewModel model)
         {
-            Instance.StartProcessInner(model);
+            // 処理実行前に、必要に応じ確認ダイアログをポップアップ表示
+            Instance.ShowPromptForStartProcess(model);
         }
 
         public static void CloseFunctionView(ToolDoProcessViewModel model)
@@ -58,6 +59,11 @@ namespace DesktopTool
         {
             // メニュー項目名を画面表示
             model.ShowTitle(MenuItemName);
+        }
+
+        protected virtual void ShowPromptForStartProcess(ToolDoProcessViewModel model)
+        {
+            StartProcessInner(model);
         }
 
         private void StartProcessInner(ToolDoProcessViewModel model)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -1,5 +1,6 @@
 ﻿using AppCommon;
 using System;
+using System.Data;
 using System.Linq;
 using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;
@@ -31,7 +32,7 @@ namespace DesktopTool
         {
             // ヘルパークラスの参照を保持
             BLEServiceRef = serviceRef;
-            
+
             // コールバックを実行
             NotifyConnection?.Invoke(this, true, string.Empty);
             NotifyConnection = null!;
@@ -87,6 +88,9 @@ namespace DesktopTool
                 sender.Disconnect();
                 AppLogUtil.OutputLogInfo(MSG_NOTIFY_DISCONNECT_BLE_DEVICE);
             }
+
+            // このクラスのコールバックを実行
+            NotifyConnectionStatus?.Invoke(this, connected);
         }
 
         public string ConnectedDeviceName()
@@ -104,6 +108,24 @@ namespace DesktopTool
                 BLEServiceRef.Disconnect();
                 AppLogUtil.OutputLogInfo(MSG_DISCONNECT_BLE_DEVICE);
             }
+        }
+
+        //
+        // 接続検知関連イベント
+        //
+        public delegate void NotifyConnectionStatusHandler(BLETransport sender, bool connected);
+        private event NotifyConnectionStatusHandler NotifyConnectionStatus = null!;
+
+        public void RegisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler handler)
+        {
+            // コールバックを設定
+            NotifyConnectionStatus += handler;
+        }
+
+        public void UnregisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler handler)
+        {
+            // コールバック設定を解除
+            NotifyConnectionStatus -= handler;
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -1,6 +1,5 @@
 ﻿using AppCommon;
 using System;
-using System.Data;
 using System.Linq;
 using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;

--- a/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
+++ b/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>VendorTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).006</FileVersion>
+    <FileVersion>$(Version).007</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
Windows版デスクトップツールに、BLEペアリング解除要求機能を本格実装します。

- ペアリング解除要求をBLEデバイスに投入後、すでに実装済みのペアリング解除待機画面をポップアップ表示
（#20 ご参照）
- 同時に、ペアリング解除による切断検知監視をスタート
- ペアリング解除による切断を検知したら、ポップアップ画面を閉じ、処理を正常終了
- タイムアウト（３０秒）内に接続検知できない場合、自動的にポップアップ画面を閉じ、処理がキャンセルされたと扱う
- 前項タイムアウト内に中止ボタンがクリックされた場合も、処理がキャンセルされたと扱う

### 制約事項
ペアリング解除要求機能が中止された後に、ユーザーがWindowsの環境設定画面でBLEデバイスを削除してしまった場合は、検知対象外とします。[注1]

<sup>
[注1] この場合はユーザーがBLEデバイスを手動でペアリングモードに遷移させたのち、ツールで再度ペアリング実行する必要があります。
</sup>