### PR TITLE
[Windows版ツール対応] ファームウェア更新機能の実装

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).008</FileVersion>
+    <FileVersion>$(Version).009</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="PeterO.Cbor" Version="4.5.2" />
     <PackageReference Include="QRCodeDecoder" Version="0.1.0" />
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEPairing.cs
@@ -3,6 +3,7 @@ using System.Security;
 using System.Threading.Tasks;
 using System.Windows;
 using static DesktopTool.FunctionMessage;
+using static DesktopTool.BLEDefines;
 
 namespace DesktopTool
 {
@@ -14,7 +15,7 @@ namespace DesktopTool
         {
             Task task = Task.Run(() => {
                 // BLEデバイスをスキャン
-                BLEPeripheralScannerParam parameter = BLEPeripheralScannerParam.PrepareParameterForFIDO();
+                BLEPeripheralScannerParam parameter = new BLEPeripheralScannerParam(U2F_BLE_SERVICE_UUID_STR);
                 new BLEPeripheralScanner().DoProcess(parameter, OnBLEPeripheralScanned);
             });
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using static DesktopTool.BLEDefines;
 using static DesktopTool.FunctionDefines;
 using static DesktopTool.FunctionMessage;
 
@@ -15,7 +16,7 @@ namespace DesktopTool
         {
             Task task = Task.Run(() => {
                 // BLEデバイスに接続
-                new BLETransport().Connect(OnNotifyConnection);
+                new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
             });
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/BLEUnpairing.cs
@@ -16,7 +16,7 @@ namespace DesktopTool
         {
             Task task = Task.Run(() => {
                 // BLEデバイスに接続
-                new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
+                new BLEU2FTransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
             });
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -29,7 +29,7 @@ namespace DesktopTool
         {
             Task task = Task.Run(() => {
                 // BLEデバイスに接続
-                new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
+                new BLEU2FTransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
             });
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEConnection/EraseBondingInfo.cs
@@ -1,8 +1,9 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using static DesktopTool.FunctionMessage;
-using static DesktopTool.FunctionDefines;
 using System.Windows;
+using static DesktopTool.BLEDefines;
+using static DesktopTool.FunctionDefines;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
@@ -28,7 +29,7 @@ namespace DesktopTool
         {
             Task task = Task.Run(() => {
                 // BLEデバイスに接続
-                new BLETransport().Connect(OnNotifyConnection);
+                new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
             });
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -14,7 +14,7 @@ namespace DesktopTool
         {
             // 接続サービスを設定
             BLEServiceParam serviceParam = new BLEServiceParam(parameter, BLE_SMP_CHARACT_UUID_STR, BLE_SMP_CHARACT_UUID_STR);
-            BLEService service = new BLEService();
+            BLESMPService service = new BLESMPService();
 
             // サービスに接続
             ConnectBLEService(service, serviceParam);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -1,0 +1,6 @@
+﻿namespace DesktopTool
+{
+    internal class BLESMPTransport : BLETransport
+    {
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -1,4 +1,7 @@
-﻿using static DesktopTool.BLEDefines;
+﻿using AppCommon;
+using System;
+using System.Linq;
+using static DesktopTool.BLEDefines;
 
 namespace DesktopTool
 {
@@ -15,6 +18,66 @@ namespace DesktopTool
 
             // サービスに接続
             ConnectBLEService(service, serviceParam);
+        }
+
+        //
+        // 送信処理
+        //
+        public override void SendRequest(byte requestCMD, byte[] requestBytes)
+        {
+            // コールバックを設定
+            BLEServiceRef.RegisterFrameReceivedHandler(FrameReceivedHandler);
+
+            // BLEデバイスにフレームを送信
+            BLEServiceRef.SendFrame(requestBytes);
+
+            // ログ出力
+            string dump = AppLogUtil.DumpMessage(requestBytes, requestBytes.Length);
+            AppLogUtil.OutputLogDebug(string.Format("Transmit SMP request ({0} bytes)\r\n{1}", requestBytes.Length, dump));
+        }
+
+
+        //
+        // 受信処理（コールバック）
+        //
+        private byte[] ReceivedResponse = Array.Empty<byte>();
+        private int ReceivedSize = 0;
+        private int TotalSize = 0;
+
+        protected override void FrameReceivedHandler(BLEService service, bool success, string errorMessage, byte[] frameBytes)
+        {
+            if (success == false) {
+                OnResponseReceived(success, errorMessage, 0x00, Array.Empty<byte>());
+                return;
+            }
+
+            // ログ出力
+            string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+            AppLogUtil.OutputLogDebug(string.Format("Incoming SMP response ({0} bytes)\r\n{1}", frameBytes.Length, dump));
+
+            // 受信したレスポンスデータを保持
+            int frameSize = frameBytes.Length;
+            if (ReceivedSize == 0) {
+                // レスポンスヘッダーからデータ長を抽出
+                TotalSize = FWUpdateTransferUtil.GetSMPResponseBodySize(frameBytes);
+
+                // 受信済みデータを保持
+                ReceivedSize = frameSize - SMP_HEADER_SIZE;
+                ReceivedResponse = new byte[ReceivedSize];
+                Array.Copy(frameBytes, SMP_HEADER_SIZE, ReceivedResponse, 0, ReceivedSize);
+
+            } else {
+                // 受信済みデータに連結
+                ReceivedSize += frameSize;
+                ReceivedResponse = ReceivedResponse.Concat(frameBytes).ToArray();
+            }
+
+            // 全フレームを受信したら、レスポンス処理を実行
+            if (ReceivedSize == TotalSize) {
+                OnResponseReceived(true, string.Empty, 0x00, ReceivedResponse);
+                ReceivedSize = 0;
+                TotalSize = 0;
+            }
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -32,8 +32,10 @@ namespace DesktopTool
             BLEServiceRef.SendFrame(requestBytes);
 
             // ログ出力
-            string dump = AppLogUtil.DumpMessage(requestBytes, requestBytes.Length);
-            AppLogUtil.OutputLogDebug(string.Format("Transmit SMP request ({0} bytes)\r\n{1}", requestBytes.Length, dump));
+            if (NoOutputLog == false) {
+                string dump = AppLogUtil.DumpMessage(requestBytes, requestBytes.Length);
+                AppLogUtil.OutputLogDebug(string.Format("Transmit SMP request ({0} bytes)\r\n{1}", requestBytes.Length, dump));
+            }
         }
 
         public void SendSMPRequestData(string commandName, byte[] requestBody, byte[] requestHeader)
@@ -63,8 +65,10 @@ namespace DesktopTool
             }
 
             // ログ出力
-            string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
-            AppLogUtil.OutputLogDebug(string.Format("Incoming SMP response ({0} bytes)\r\n{1}", frameBytes.Length, dump));
+            if (NoOutputLog == false) {
+                string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+                AppLogUtil.OutputLogDebug(string.Format("Incoming SMP response ({0} bytes)\r\n{1}", frameBytes.Length, dump));
+            }
 
             // 受信したレスポンスデータを保持
             int frameSize = frameBytes.Length;

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -36,6 +36,17 @@ namespace DesktopTool
             AppLogUtil.OutputLogDebug(string.Format("Transmit SMP request ({0} bytes)\r\n{1}", requestBytes.Length, dump));
         }
 
+        public void SendSMPRequestData(string commandName, byte[] requestBody, byte[] requestHeader)
+        {
+            // 実行コマンド名を保持
+            CommandName = commandName;
+
+            // ヘッダーと本体を連結
+            byte[] requestData = Enumerable.Concat(requestHeader, requestBody).ToArray();
+
+            // リクエストデータを送信
+            SendRequest(0x00, requestData);
+        }
 
         //
         // 受信処理（コールバック）

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLESMPTransport.cs
@@ -1,6 +1,20 @@
-﻿namespace DesktopTool
+﻿using static DesktopTool.BLEDefines;
+
+namespace DesktopTool
 {
     internal class BLESMPTransport : BLETransport
     {
+        //
+        // 接続処理
+        //
+        protected override void SetupBLEService(BLEPeripheralScannerParam parameter)
+        {
+            // 接続サービスを設定
+            BLEServiceParam serviceParam = new BLEServiceParam(parameter, BLE_SMP_CHARACT_UUID_STR, BLE_SMP_CHARACT_UUID_STR);
+            BLEService service = new BLEService();
+
+            // サービスに接続
+            ConnectBLEService(service, serviceParam);
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEU2FTransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/BLEU2FTransport.cs
@@ -1,0 +1,204 @@
+﻿using AppCommon;
+using System;
+using System.Linq;
+using static DesktopTool.BLEDefines;
+
+namespace DesktopTool
+{
+    internal class BLEU2FTransport : BLETransport
+    {
+        //
+        // 接続処理
+        //
+        protected override void SetupBLEService(BLEPeripheralScannerParam parameter)
+        {
+            // 接続サービスを設定
+            BLEServiceParam serviceParam = new BLEServiceParam(parameter, U2F_STATUS_CHAR_UUID_STR, U2F_CONTROL_POINT_CHAR_UUID_STR);
+            BLEService service = new BLEService();
+
+            // サービスに接続
+            ConnectBLEService(service, serviceParam);
+        }
+
+        //
+        // 送信処理
+        //
+        public override void SendRequest(byte requestCMD, byte[] requestBytes)
+        {
+            // コールバックを設定
+            BLEServiceRef.RegisterFrameReceivedHandler(FrameReceivedHandler);
+
+            // APDUの長さを取得
+            int transferBytesLen = requestBytes.Length;
+            if (transferBytesLen == 0) {
+                // データ長０のフレームを送信
+                byte[] frame = new byte[] { requestCMD, 0, 0 };
+                BLEServiceRef.SendFrame(frame);
+                AppLogUtil.OutputLogDebug("BLE Sent INIT frame: data size=0");
+                return;
+            }
+
+            // 
+            // 送信データをフレーム分割
+            // 
+            //  INITフレーム
+            //  1     バイト目: コマンド
+            //  2 - 3 バイト目: データ長
+            //  残りのバイト  : データ部（64 - 3 = 61）
+            //
+            //  CONTフレーム
+            //  1     バイト目: シーケンス
+            //  残りのバイト  : データ部（64 - 1 = 63）
+            // 
+            byte[] frameData = new byte[U2F_BLE_FRAME_LEN];
+            int transferred = 0;
+            int seq = 0;
+            while (transferred < transferBytesLen) {
+                for (int j = 0; j < frameData.Length; j++) {
+                    // フレームデータを初期化
+                    frameData[j] = 0;
+                }
+
+                int frameLen;
+                if (transferred == 0) {
+                    // INITフレーム
+                    // ヘッダーをコピー
+                    frameData[0] = (byte)(0x80 | requestCMD);
+                    frameData[1] = (byte)(transferBytesLen / 256);
+                    frameData[2] = (byte)(transferBytesLen % 256);
+
+                    // データをコピー
+                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
+                    int dataLenInFrame = (transferBytesLen < maxLen) ? transferBytesLen : maxLen;
+                    for (int i = 0; i < dataLenInFrame; i++) {
+                        frameData[U2F_BLE_INIT_HEADER_LEN + i] = requestBytes[transferred++];
+                    }
+
+                    // フレーム長を取得
+                    frameLen = U2F_BLE_INIT_HEADER_LEN + dataLenInFrame;
+
+                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
+                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent INIT frame: data size={0} length={1}\r\n{2}",
+                        transferBytesLen, dataLenInFrame, dump));
+
+                } else {
+                    // CONTフレーム
+                    // ヘッダーをコピー
+                    frameData[0] = (byte)seq;
+
+                    // データをコピー
+                    int remaining = transferBytesLen - transferred;
+                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
+                    int dataLenInFrame = (remaining < maxLen) ? remaining : maxLen;
+                    for (int i = 0; i < dataLenInFrame; i++) {
+                        frameData[U2F_BLE_CONT_HEADER_LEN + i] = requestBytes[transferred++];
+                    }
+
+                    // フレーム長を取得
+                    frameLen = U2F_BLE_CONT_HEADER_LEN + dataLenInFrame;
+
+                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
+                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent CONT frame: data seq={0} length={1}\r\n{2}",
+                        seq++, dataLenInFrame, dump));
+                }
+
+                // BLEデバイスにフレームを送信
+                BLEServiceRef.SendFrame(frameData.Take(frameLen).ToArray());
+            }
+        }
+
+        //
+        // 受信処理（コールバック）
+        //
+        private byte[] ReceivedResponse = Array.Empty<byte>();
+        private int ReceivedResponseLen = 0;
+        private int ReceivedSize = 0;
+
+        protected override void FrameReceivedHandler(BLEService service, bool success, string errorMessage, byte[] frameBytes)
+        {
+            if (success == false) {
+                OnResponseReceived(success, errorMessage, 0x00, Array.Empty<byte>());
+                return;
+            }
+
+            // 
+            // 受信したデータをバッファにコピー
+            // 
+            //  INITフレーム
+            //  1     バイト目: コマンド
+            //  2 - 3 バイト目: データ長
+            //  残りのバイト  : データ部（64 - 3 = 61）
+            //
+            //  CONTフレーム
+            //  1     バイト目: シーケンス
+            //  残りのバイト  : データ部（64 - 1 = 63）
+            // 
+            int bleInitDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
+            int bleContDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
+            byte cmd = frameBytes[0];
+            if (cmd > 127) {
+                // INITフレームであると判断
+                byte cnth = frameBytes[1];
+                byte cntl = frameBytes[2];
+                ReceivedResponseLen = cnth * 256 + cntl;
+                ReceivedResponse = new byte[U2F_BLE_INIT_HEADER_LEN + ReceivedResponseLen];
+                ReceivedSize = 0;
+
+                // ヘッダーをコピー
+                for (int i = 0; i < U2F_BLE_INIT_HEADER_LEN; i++) {
+                    ReceivedResponse[i] = frameBytes[i];
+                }
+
+                // データをコピー
+                int dataLenInFrame = (ReceivedResponseLen < bleInitDataLen) ? ReceivedResponseLen : bleInitDataLen;
+                for (int i = 0; i < dataLenInFrame; i++) {
+                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_INIT_HEADER_LEN + i];
+                }
+
+                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
+                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD) == false) {
+                    // キープアライブ以外の場合はログを出力
+                    string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+                    AppLogUtil.OutputLogDebug(string.Format(
+                        "BLE Recv INIT frame: data size={0} length={1}\r\n{2}",
+                        ReceivedResponseLen, dataLenInFrame, dump));
+                }
+
+            } else {
+                // CONTフレームであると判断
+                int seq = frameBytes[0];
+
+                // データをコピー
+                int remaining = ReceivedResponseLen - ReceivedSize;
+                int dataLenInFrame = (remaining < bleContDataLen) ? remaining : bleContDataLen;
+                for (int i = 0; i < dataLenInFrame; i++) {
+                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_CONT_HEADER_LEN + i];
+                }
+
+                string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
+                AppLogUtil.OutputLogDebug(string.Format(
+                    "BLE Recv CONT frame: seq={0} length={1}\r\n{2}",
+                    seq, dataLenInFrame, dump));
+            }
+
+            // 全フレームがそろった場合
+            if (ReceivedSize == ReceivedResponseLen) {
+                // CMDを抽出
+                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
+                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD)) {
+                    // キープアライブの場合は引き続き次のレスポンスを待つ
+                    return;
+                }
+
+                // 受信データを転送
+                if (ReceivedResponseLen == 0) {
+                    OnResponseReceived(true, string.Empty, responseCMD, Array.Empty<byte>());
+
+                } else {
+                    byte[] response = ReceivedResponse.Skip(U2F_BLE_INIT_HEADER_LEN).ToArray();
+                    OnResponseReceived(true, string.Empty, responseCMD, response);
+                }
+            }
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -50,7 +50,7 @@ namespace DesktopTool
                 CancelCommand(false, errorMessage);
                 return;
             }
-            
+
             // ファームウェアの現在バージョン／更新バージョンを画面表示
             string message = string.Format(MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, sender.VersionData.FWRev, sender.UpdateImageData.UpdateVersion);
             LogAndShowInfoMessage(message);
@@ -83,7 +83,7 @@ namespace DesktopTool
 
                 } else {
                     // 転送処理時にエラーが発生した場合
-                    TerminateCommand(false, string.Empty);
+                    OnUpdateImageTransferFailed();
                 }
 
             } else {
@@ -219,6 +219,11 @@ namespace DesktopTool
                 // TODO: 仮の実装です。
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, true);
             }
+
+            if (sender.Status == TransferStatusFailed) {
+                // ファームウェア更新進捗画面を閉じる
+                Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, false);
+            }
         }
 
         private void CancelUpdateImageTransfer()
@@ -231,6 +236,15 @@ namespace DesktopTool
 
             // 転送処理中止を要求
             updateTransfer.Cancel();
+        }
+
+        private void OnUpdateImageTransferFailed()
+        {
+            // ファームウェア更新イメージ転送クラスの参照を共有情報から取得
+            FWUpdateTransfer updateTransfer = (FWUpdateTransfer)ProcessContext[nameof(FWUpdateTransfer)];
+
+            // 異常終了扱いとする
+            TerminateCommand(false, updateTransfer.ErrorMessage);
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -174,9 +174,14 @@ namespace DesktopTool
 
         private void UpdateImageTransferHandler(FWUpdateTransfer sender)
         {
-            if (sender.Status == TransferStatusStarted) {
+            if (sender.Status == TransferStatusStarting) {
                 // ファームウェア更新イメージ転送クラスの参照を共有情報に保持
                 ProcessContext[nameof(FWUpdateTransfer)] = sender;
+            }
+
+            if (sender.Status == TransferStatusStarted) {
+                // ファームウェア更新進捗画面の中止ボタンを使用可能とする
+                FWUpdateProgress.EnableButtonClose(true);
             }
 
             if (sender.Status == TransferStatusUpdateProgress) {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -4,7 +4,6 @@ using static DesktopTool.FunctionMessage;
 using static DesktopTool.FWUpdateConst;
 using static DesktopTool.FWUpdateProgress.ProgressStatus;
 
-
 namespace DesktopTool
 {
     public class FWUpdateConst
@@ -83,10 +82,10 @@ namespace DesktopTool
             // 初期表示時の処理
             if (sender.Status == ProgressStatusInitView) {
                 // 最大待機秒数を設定
-                FWUpdateProgress.SetMaxProgress(sender.ViewModel, 100 + DFU_WAITING_SEC_ESTIMATED);
+                FWUpdateProgress.SetMaxProgress(100 + DFU_WAITING_SEC_ESTIMATED);
 
                 // メッセージを初期表示
-                FWUpdateProgress.ShowProgress(sender.ViewModel, MSG_FW_UPDATE_PRE_PROCESS, 0);
+                FWUpdateProgress.ShowProgress(MSG_FW_UPDATE_PRE_PROCESS, 0);
             }
 
             // 中止ボタンクリック時の処理

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -67,9 +67,16 @@ namespace DesktopTool
             }
 
             // ファームウェア更新進捗画面を表示
-            if (new FWUpdateProgress().OpenForm(FWUpdateProgressHandler) == false) {
-                // TODO: 仮の実装です。
-                CancelProcess();
+            FWUpdateProgress UpdateProgress = new FWUpdateProgress();
+            if (UpdateProgress.OpenForm(FWUpdateProgressHandler) == false) {
+                if (UpdateProgress.Status == ProgressStatusCancelClicked) {
+                    // ユーザーが中止ボタンをクリックした場合
+                    CancelProcess();
+
+                } else {
+                    // 転送処理時にエラーが発生した場合
+                    TerminateCommand(false, string.Empty);
+                }
 
             } else {
                 // 更新後ファームウェアのバージョンをチェック

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -101,11 +101,8 @@ namespace DesktopTool
 
             // 中止ボタンクリック時の処理
             if (sender.Status == ProgressStatusCancelClicked) {
-                // メッセージを画面表示／ログ出力
-                LogAndShowInfoMessage(MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED);
-
-                // ファームウェア更新進捗画面を閉じる
-                FWUpdateProgress.CloseForm(false);
+                // ファームウェア更新イメージ転送処理を中止
+                CancelUpdateImageTransfer();
             }
         }
 
@@ -188,10 +185,27 @@ namespace DesktopTool
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.ShowProgress, message, sender.Progress);
             }
 
+            if (sender.Status == TransferStatusCanceled) {
+                // ファームウェア更新進捗画面を閉じる
+                Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, false);
+            }
+
             if (sender.Status == TransferStatusCompleted) {
                 // TODO: 仮の実装です。
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, true);
             }
+        }
+
+        private void CancelUpdateImageTransfer()
+        {
+            // メッセージを画面表示／ログ出力
+            LogAndShowInfoMessage(MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED);
+
+            // ファームウェア更新イメージ転送クラスの参照を共有情報から取得
+            FWUpdateTransfer updateTransfer = (FWUpdateTransfer)ProcessContext[nameof(FWUpdateTransfer)];
+
+            // 転送処理中止を要求
+            updateTransfer.Cancel();
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -210,6 +210,11 @@ namespace DesktopTool
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, false);
             }
 
+            if (sender.Status == TransferStatusUploadCompleted) {
+                // 転送成功を通知
+                LogAndShowInfoMessage(MSG_FW_UPDATE_PROCESS_TRANSFER_SUCCESS);
+            }
+
             if (sender.Status == TransferStatusWaitingUpdate) {
                 // ファームウェア更新進捗画面の中止ボタンを使用不能とする
                 FWUpdateProgress.EnableButtonClose(false);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -198,6 +198,16 @@ namespace DesktopTool
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, false);
             }
 
+            if (sender.Status == TransferStatusWaitingUpdate) {
+                // ファームウェア更新進捗画面の中止ボタンを使用不能とする
+                FWUpdateProgress.EnableButtonClose(false);
+            }
+
+            if (sender.Status == TransferStatusWaitingUpdateProgress) {
+                // ファームウェア更新進捗画面に進捗を表示
+                Application.Current.Dispatcher.Invoke(FWUpdateProgress.ShowProgress, MSG_FW_UPDATE_PROCESS_WAITING_UPDATE, sender.Progress);
+            }
+
             if (sender.Status == TransferStatusCompleted) {
                 // TODO: 仮の実装です。
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, true);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -66,7 +66,7 @@ namespace DesktopTool
             }
 
             // ファームウェア更新進捗画面を表示
-            if (new FWUpdateProgress().OpenForm(InitFWUpdateProgressWindow) == false) {
+            if (new FWUpdateProgress().OpenForm(FWUpdateProgressHandler) == false) {
                 // TODO: 仮の実装です。
                 CancelProcess();
 
@@ -76,13 +76,13 @@ namespace DesktopTool
             }
         }
 
-        private void InitFWUpdateProgressWindow(FWUpdateProgress sender, FWUpdateProgressViewModel model)
+        private void FWUpdateProgressHandler(FWUpdateProgress sender)
         {
             // 最大待機秒数を設定
-            FWUpdateProgress.SetMaxProgress(model, 100 + DFU_WAITING_SEC_ESTIMATED);
+            FWUpdateProgress.SetMaxProgress(sender.ViewModel, 100 + DFU_WAITING_SEC_ESTIMATED);
 
             // メッセージを初期表示
-            FWUpdateProgress.ShowProgress(model, MSG_FW_UPDATE_PRE_PROCESS, 0);
+            FWUpdateProgress.ShowProgress(sender.ViewModel, MSG_FW_UPDATE_PRE_PROCESS, 0);
         }
 
         private void CheckUpdatedFWVersion()

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -108,6 +108,9 @@ namespace DesktopTool
 
         private void CheckUpdatedFWVersion()
         {
+            // メッセージを画面表示／ログ出力
+            LogAndShowInfoMessage(MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION);
+
             // BLEデバイスに接続し、更新後ファームウェアのバージョン情報を取得
             new FWVersion().Inquiry(UpdatedFWVersionResponseHandler);
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -189,6 +189,11 @@ namespace DesktopTool
                 ProcessContext[nameof(FWUpdateTransfer)] = sender;
             }
 
+            if (sender.Status == TransferStatusPreprocess) {
+                // ファームウェア更新進捗画面にメッセージを表示
+                Application.Current.Dispatcher.Invoke(FWUpdateProgress.ShowProgress, MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE, sender.Progress);
+            }
+
             if (sender.Status == TransferStatusStarted) {
                 // ファームウェア更新進捗画面の中止ボタンを使用可能とする
                 FWUpdateProgress.EnableButtonClose(true);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -24,6 +24,9 @@ namespace DesktopTool
 
         private void RetrieveCurrentFWVersion()
         {
+            // メッセージを画面表示／ログ出力
+            LogAndShowInfoMessage(MSG_FW_UPDATE_CURRENT_VERSION_CONFIRM);
+
             // BLEデバイスに接続し、ファームウェアのバージョン情報を取得
             new FWVersion().Inquiry(NotifyResponseQueryHandler);
         }
@@ -47,6 +50,10 @@ namespace DesktopTool
                 CancelCommand(false, errorMessage);
                 return;
             }
+            
+            // ファームウェアの現在バージョン／更新バージョンを画面表示
+            string message = string.Format(MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, sender.VersionData.FWRev, sender.UpdateImageData.UpdateVersion);
+            LogAndShowInfoMessage(message);
 
             // ファームウェア更新イメージの参照を共有情報に保持
             ProcessContext[nameof(FWUpdateImage)] = sender;

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -177,6 +177,11 @@ namespace DesktopTool
 
         private void UpdateImageTransferHandler(FWUpdateTransfer sender)
         {
+            if (sender.Status == TransferStatusStarted) {
+                // ファームウェア更新イメージ転送クラスの参照を共有情報に保持
+                ProcessContext[nameof(FWUpdateTransfer)] = sender;
+            }
+
             if (sender.Status == TransferStatusUpdateProgress) {
                 // ファームウェア更新進捗画面に進捗を表示
                 string message = string.Format(MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT, sender.Progress);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -226,7 +226,7 @@ namespace DesktopTool
             }
 
             if (sender.Status == TransferStatusCompleted) {
-                // TODO: 仮の実装です。
+                // ファームウェア更新進捗画面を閉じる
                 Application.Current.Dispatcher.Invoke(FWUpdateProgress.CloseForm, true);
             }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -141,7 +141,7 @@ namespace DesktopTool
             if (CurrentVersion == UpdateVersion) {
                 TerminateCommand(success, string.Format(MSG_FW_UPDATE_VERSION_SUCCESS, UpdateVersion));
             } else {
-                TerminateCommand(success, string.Format(MSG_FW_UPDATE_VERSION_FAIL, UpdateVersion));
+                TerminateCommand(false, string.Format(MSG_FW_UPDATE_VERSION_FAIL, UpdateVersion));
             }
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -2,6 +2,8 @@
 using System.Windows;
 using static DesktopTool.FunctionMessage;
 using static DesktopTool.FWUpdateConst;
+using static DesktopTool.FWUpdateProgress.ProgressStatus;
+
 
 namespace DesktopTool
 {
@@ -78,11 +80,14 @@ namespace DesktopTool
 
         private void FWUpdateProgressHandler(FWUpdateProgress sender)
         {
-            // 最大待機秒数を設定
-            FWUpdateProgress.SetMaxProgress(sender.ViewModel, 100 + DFU_WAITING_SEC_ESTIMATED);
+            // 初期表示時の処理
+            if (sender.Status == ProgressStatusInitView) {
+                // 最大待機秒数を設定
+                FWUpdateProgress.SetMaxProgress(sender.ViewModel, 100 + DFU_WAITING_SEC_ESTIMATED);
 
-            // メッセージを初期表示
-            FWUpdateProgress.ShowProgress(sender.ViewModel, MSG_FW_UPDATE_PRE_PROCESS, 0);
+                // メッセージを初期表示
+                FWUpdateProgress.ShowProgress(sender.ViewModel, MSG_FW_UPDATE_PRE_PROCESS, 0);
+            }
         }
 
         private void CheckUpdatedFWVersion()

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -49,7 +49,7 @@ namespace DesktopTool
             }
 
             // ファームウェア更新イメージの参照を共有情報に保持
-            ProcessContext.Add(nameof(FWUpdateImage), sender);
+            ProcessContext[nameof(FWUpdateImage)] = sender;
 
             // ファームウェア更新進捗画面を表示
             Application.Current.Dispatcher.Invoke(ShowFWUpdateProcessWindow);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -88,6 +88,15 @@ namespace DesktopTool
                 // メッセージを初期表示
                 FWUpdateProgress.ShowProgress(sender.ViewModel, MSG_FW_UPDATE_PRE_PROCESS, 0);
             }
+
+            // 中止ボタンクリック時の処理
+            if (sender.Status == ProgressStatusCancelClicked) {
+                // メッセージを画面表示／ログ出力
+                LogAndShowInfoMessage(sender.ErrorMessage);
+
+                // ファームウェア更新進捗画面を閉じる
+                FWUpdateProgress.CloseForm(false);
+            }
         }
 
         private void CheckUpdatedFWVersion()

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdate.cs
@@ -102,7 +102,7 @@ namespace DesktopTool
             // 中止ボタンクリック時の処理
             if (sender.Status == ProgressStatusCancelClicked) {
                 // メッセージを画面表示／ログ出力
-                LogAndShowInfoMessage(sender.ErrorMessage);
+                LogAndShowInfoMessage(MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED);
 
                 // ファームウェア更新進捗画面を閉じる
                 FWUpdateProgress.CloseForm(false);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateCBORDecoder.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateCBORDecoder.cs
@@ -1,0 +1,239 @@
+﻿using AppCommon;
+using PeterO.Cbor;
+using System;
+
+namespace DesktopTool
+{
+    internal class FWUpdateResultInfo
+    {
+        public byte Rc { get; set; }
+        public UInt32 Off { get; set; }
+    }
+
+    internal class FWUpdateSlotInfo
+    {
+        public byte SlotNo { get; set; }
+        public byte[] Hash { get; set; }
+        public bool Active { get; set; }
+
+        public FWUpdateSlotInfo()
+        {
+            Hash = new byte[0];
+        }
+    }
+
+    internal class FWUpdateCBORDecoder
+    {
+        public FWUpdateResultInfo ResultInfo { get; set; }
+        public FWUpdateSlotInfo[] SlotInfos { get; set; }
+
+        public FWUpdateCBORDecoder()
+        {
+            // スロット照会情報を初期化
+            SlotInfos = new FWUpdateSlotInfo[2];
+            for (int i = 0; i < SlotInfos.Length; i++) {
+                SlotInfos[i] = new FWUpdateSlotInfo();
+            }
+
+            // 転送結果情報を初期化
+            ResultInfo = new FWUpdateResultInfo();
+        }
+
+        public bool DecodeSlotInfo(byte[] cborBytes)
+        {
+            // ルートのMapを抽出
+            CBORObject slotInfoMap = CBORObject.DecodeFromBytes(cborBytes, CBOREncodeOptions.Default);
+
+            // Map内を探索
+            foreach (CBORObject slotInfoKey in slotInfoMap.Keys) {
+                string keyStr = slotInfoKey.AsString();
+                if (keyStr.Equals("images")) {
+                    // "images"エントリーを抽出（配列）
+                    if (ParseImageArray(slotInfoMap, slotInfoKey) == false) {
+                        return false;
+                    }
+                }
+
+                if (keyStr.Equals("rc")) {
+                    // "images"がない場合は、代わりに"rc"を抽出
+                    byte rc = 0;
+                    if (ParseByteValue(slotInfoMap, slotInfoKey, ref rc) == false) {
+                        return false;
+                    }
+                    ResultInfo.Rc = rc;
+                }
+            }
+            return true;
+        }
+
+        public bool DecodeUploadResultInfo(byte[] cborBytes)
+        {
+            // ルートのMapを抽出
+            CBORObject uploadResultInfoMap = CBORObject.DecodeFromBytes(cborBytes, CBOREncodeOptions.Default);
+
+            // Map内を探索
+            foreach (CBORObject uploadResultInfoKey in uploadResultInfoMap.Keys) {
+                string keyStr = uploadResultInfoKey.AsString();
+                if (keyStr.Equals("rc")) {
+                    // "rc"エントリーを抽出（数値）
+                    byte rc = 0;
+                    if (ParseByteValue(uploadResultInfoMap, uploadResultInfoKey, ref rc) == false) {
+                        return false;
+                    }
+                    ResultInfo.Rc = rc;
+                }
+                if (keyStr.Equals("off")) {
+                    // "off"エントリーを抽出（数値）
+                    UInt32 off = 0;
+                    if (ParseUInt32Value(uploadResultInfoMap, uploadResultInfoKey, ref off) == false) {
+                        return false;
+                    }
+                    ResultInfo.Off = off;
+                }
+            }
+            return true;
+        }
+
+        private bool ParseImageArray(CBORObject map, CBORObject key)
+        {
+            // Mapから指定キーのエントリーを抽出
+            CBORObject imageArray = map[key];
+            if (imageArray == null) {
+                AppLogUtil.OutputLogError(string.Format("ParseImageArray: {0} is null", key.AsString()));
+                return false;
+            }
+
+            // 型をチェック
+            if (imageArray.Type != CBORType.Array) {
+                AppLogUtil.OutputLogError(string.Format("ParseImageArray: {0} is not CBORType.Array", key.AsString()));
+                return false;
+            }
+
+            // 配列内を探索
+            int idx = 0;
+            foreach (CBORObject imageMap in imageArray.Values) {
+                // 型をチェック
+                if (imageMap.Type != CBORType.Map) {
+                    AppLogUtil.OutputLogError(string.Format("ParseImageArray: idx[{0}] is not CBORType.Map", idx));
+                    return false;
+                }
+
+                // 抽出する値を格納
+                byte slotNo = 0;
+                byte[] hash = new byte[0];
+                bool active = false;
+
+                // Map内を探索
+                foreach (CBORObject imageKey in imageMap.Keys) {
+                    string imageKeyStr = imageKey.AsString();
+                    if (imageKeyStr.Equals("slot")) {
+                        // "slot"エントリーを抽出（数値）
+                        if (ParseByteValue(imageMap, imageKey, ref slotNo) == false) {
+                            return false;
+                        }
+                        SlotInfos[slotNo].SlotNo = slotNo;
+                    }
+
+                    if (imageKeyStr.Equals("hash")) {
+                        // "hash"エントリーを抽出（バイト配列）
+                        if (ParseFixedBytesValue(imageMap, imageKey, ref hash) == false) {
+                            return false;
+                        }
+                        SlotInfos[slotNo].Hash = hash;
+                    }
+
+                    if (imageKeyStr.Equals("active")) {
+                        // "active"エントリーを抽出（bool）
+                        if (ParseBooleanValue(imageMap, imageKey, ref active) == false) {
+                            return false;
+                        }
+                        SlotInfos[slotNo].Active = active;
+                    }
+                }
+                idx++;
+            }
+
+            return true;
+        }
+
+        private bool ParseByteValue(CBORObject map, CBORObject key, ref byte b)
+        {
+            // Mapから指定キーのエントリーを抽出
+            CBORObject value = map[key];
+            if (value == null) {
+                AppLogUtil.OutputLogError(string.Format("ParseByteValue: {0} is null", key.AsString()));
+                return false;
+            }
+
+            // 型をチェック
+            if (value.Type != CBORType.Integer) {
+                AppLogUtil.OutputLogError(string.Format("ParseByteValue: {0} is not CBORType.Number", key.AsString()));
+                return false;
+            }
+
+            // 値を抽出
+            b = value.ToObject<byte>();
+            return true;
+        }
+
+        private bool ParseFixedBytesValue(CBORObject map, CBORObject key, ref byte[] b)
+        {
+            // Mapから指定キーのエントリーを抽出
+            CBORObject value = map[key];
+            if (value == null) {
+                AppLogUtil.OutputLogError(string.Format("ParseFixedBytesValue: {0} is null", key.AsString()));
+                return false;
+            }
+
+            // 型をチェック
+            if (value.Type != CBORType.ByteString) {
+                AppLogUtil.OutputLogError(string.Format("ParseFixedBytesValue: {0} is not CBORType.ByteString", key.AsString()));
+                return false;
+            }
+
+            // 値を抽出
+            b = value.GetByteString();
+            return true;
+        }
+
+        private bool ParseBooleanValue(CBORObject map, CBORObject key, ref bool b)
+        {
+            // Mapから指定キーのエントリーを抽出
+            CBORObject value = map[key];
+            if (value == null) {
+                AppLogUtil.OutputLogError(string.Format("ParseBooleanValue: {0} is null", key.AsString()));
+                return false;
+            }
+
+            // 型をチェック
+            if (value.Type != CBORType.Boolean) {
+                AppLogUtil.OutputLogError(string.Format("ParseBooleanValue: {0} is not CBORType.Boolean", key.AsString()));
+                return false;
+            }
+
+            // 値を抽出
+            b = value.AsBoolean();
+            return true;
+        }
+
+        private bool ParseUInt32Value(CBORObject map, CBORObject key, ref UInt32 ui)
+        {
+            // Mapから指定キーのエントリーを抽出
+            CBORObject value = map[key];
+            if (value == null) {
+                AppLogUtil.OutputLogError(string.Format("ParseUInt32Value: {0} is null", key.AsString()));
+                return false;
+            }
+
+            // 型をチェック
+            if (value.Type != CBORType.Integer) {
+                AppLogUtil.OutputLogError(string.Format("ParseUInt32Value: {0} is not CBORType.Number", key.AsString()));
+                return false;
+            }
+
+            // 値を抽出
+            ui = value.AsNumber().ToUInt32Checked();
+            return true;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -79,6 +79,12 @@ namespace DesktopTool
             model.ShowRemaining(caption);
         }
 
+        public static void EnableButtonClose(bool isEnabled)
+        {
+            // 閉じるボタンを使用可能／不可能に設定
+            FunctionUtil.EnableButtonClickOnApp(isEnabled, Instance.ViewModel.EnableButtonClose);
+        }
+
         //
         // コールバック関数
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -9,6 +9,9 @@ namespace DesktopTool
         public static FWUpdateProgress Instance = null!;
         private FWUpdateProgressWindow Window = null!;
 
+        // プロパティー
+        public string ErrorMessage { get; private set; }
+
         // ファームウェア更新進捗画面表示時のコールバックを保持
         public delegate void InitFWUpdateProgressWindowHandler(FWUpdateProgress sender, FWUpdateProgressViewModel model);
         private InitFWUpdateProgressWindowHandler InitFWUpdateProgressWindow = null!;
@@ -16,6 +19,7 @@ namespace DesktopTool
         public FWUpdateProgress()
         {
             Instance = this;
+            ErrorMessage = string.Empty;
         }
 
         public bool OpenForm(InitFWUpdateProgressWindowHandler handler)
@@ -34,7 +38,7 @@ namespace DesktopTool
             }
         }
 
-        private void NotifyTerminateInner(bool b, string errorMessage)
+        private void NotifyTerminateInner(bool b)
         {
             // ファームウェア更新進捗画面を閉じる
             Window.DialogResult = b;
@@ -72,8 +76,11 @@ namespace DesktopTool
 
         public static void OnCancel(FWUpdateProgressViewModel model)
         {
+            // エラーメッセージを設定
+            Instance.ErrorMessage = MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED;
+
             // TODO: 仮の実装です。
-            Instance.NotifyTerminateInner(false, string.Empty);
+            Instance.NotifyTerminateInner(false);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -11,21 +11,23 @@ namespace DesktopTool
 
         // プロパティー
         public string ErrorMessage { get; private set; }
+        public FWUpdateProgressViewModel ViewModel { get; private set; }
 
         // ファームウェア更新進捗画面表示時のコールバックを保持
-        public delegate void InitFWUpdateProgressWindowHandler(FWUpdateProgress sender, FWUpdateProgressViewModel model);
-        private InitFWUpdateProgressWindowHandler InitFWUpdateProgressWindow = null!;
+        public delegate void FWUpdateProgressHandler(FWUpdateProgress sender);
+        private FWUpdateProgressHandler UpdateProgressHandler = null!;
 
         public FWUpdateProgress()
         {
             Instance = this;
             ErrorMessage = string.Empty;
+            ViewModel = null!;
         }
 
-        public bool OpenForm(InitFWUpdateProgressWindowHandler handler)
+        public bool OpenForm(FWUpdateProgressHandler handler)
         {
             // ファームウェア更新進捗画面表示時のコールバックを保持
-            InitFWUpdateProgressWindow = handler;
+            UpdateProgressHandler = handler;
 
             // ファームウェア更新進捗画面を、ホーム画面の中央にモード付きで表示
             Window = new FWUpdateProgressWindow();
@@ -67,11 +69,14 @@ namespace DesktopTool
         //
         public static void InitView(FWUpdateProgressViewModel model)
         {
+            // ViewModelの参照を保持
+            Instance.ViewModel = model;
+
             // タイトルを画面表示
             model.ShowTitle(MSG_FW_UPDATE_PROCESSING);
 
-            // 上位クラスの関数をコールバック
-            Instance.InitFWUpdateProgressWindow(Instance, model);
+            // 画面が表示された旨を通知
+            Instance.UpdateProgressHandler(Instance);
         }
 
         public static void OnCancel(FWUpdateProgressViewModel model)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -21,7 +21,6 @@ namespace DesktopTool
 
         // プロパティー
         public ProgressStatus Status { get; private set; }
-        public string ErrorMessage { get; private set; }
 
         // ファームウェア更新進捗画面表示時のコールバックを保持
         public delegate void FWUpdateProgressHandler(FWUpdateProgress sender);
@@ -30,7 +29,6 @@ namespace DesktopTool
         public FWUpdateProgress()
         {
             Instance = this;
-            ErrorMessage = string.Empty;
         }
 
         public bool OpenForm(FWUpdateProgressHandler handler)
@@ -98,9 +96,6 @@ namespace DesktopTool
 
         public static void OnCancel()
         {
-            // エラーメッセージを設定
-            Instance.ErrorMessage = MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED;
-
             // 中止ボタンがクリックされた旨を通知
             Instance.HandleUpdateProgress(ProgressStatusCancelClicked);
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -17,11 +17,11 @@ namespace DesktopTool
         // このクラスのインスタンス
         private static FWUpdateProgress Instance = null!;
         private FWUpdateProgressWindow Window = null!;
+        private FWUpdateProgressViewModel ViewModel = null!;
 
         // プロパティー
         public ProgressStatus Status { get; private set; }
         public string ErrorMessage { get; private set; }
-        public FWUpdateProgressViewModel ViewModel { get; private set; }
 
         // ファームウェア更新進捗画面表示時のコールバックを保持
         public delegate void FWUpdateProgressHandler(FWUpdateProgress sender);
@@ -31,7 +31,6 @@ namespace DesktopTool
         {
             Instance = this;
             ErrorMessage = string.Empty;
-            ViewModel = null!;
         }
 
         public bool OpenForm(FWUpdateProgressHandler handler)
@@ -67,15 +66,17 @@ namespace DesktopTool
             Instance.NotifyTerminateInner(dialogResult);
         }
 
-        public static void SetMaxProgress(FWUpdateProgressViewModel model, int maxProgress)
+        public static void SetMaxProgress(int maxProgress)
         {
             // 進捗度の最大値を画面に反映させる
+            FWUpdateProgressViewModel model = Instance.ViewModel;
             model.SetMaxLevel(maxProgress);
         }
 
-        public static void ShowProgress(FWUpdateProgressViewModel model, string caption, int progressing)
+        public static void ShowProgress(string caption, int progressing)
         {
             // メッセージを表示し、進捗度を画面に反映させる
+            FWUpdateProgressViewModel model = Instance.ViewModel;
             model.SetLevel(progressing);
             model.ShowRemaining(caption);
         }
@@ -95,7 +96,7 @@ namespace DesktopTool
             Instance.HandleUpdateProgress(ProgressStatusInitView);
         }
 
-        public static void OnCancel(FWUpdateProgressViewModel model)
+        public static void OnCancel()
         {
             // エラーメッセージを設定
             Instance.ErrorMessage = MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED;

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -14,7 +14,7 @@ namespace DesktopTool
         };
 
         // このクラスのインスタンス
-        public static FWUpdateProgress Instance = null!;
+        private static FWUpdateProgress Instance = null!;
         private FWUpdateProgressWindow Window = null!;
 
         // プロパティー

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -1,15 +1,24 @@
 ﻿using System.Windows;
 using static DesktopTool.FunctionMessage;
+using static DesktopTool.FWUpdateProgress.ProgressStatus;
 
 namespace DesktopTool
 {
     internal class FWUpdateProgress
     {
+        // ステータス
+        public enum ProgressStatus
+        {
+            ProgressStatusNone = 0,
+            ProgressStatusInitView,
+        };
+
         // このクラスのインスタンス
         public static FWUpdateProgress Instance = null!;
         private FWUpdateProgressWindow Window = null!;
 
         // プロパティー
+        public ProgressStatus Status { get; private set; }
         public string ErrorMessage { get; private set; }
         public FWUpdateProgressViewModel ViewModel { get; private set; }
 
@@ -76,7 +85,7 @@ namespace DesktopTool
             model.ShowTitle(MSG_FW_UPDATE_PROCESSING);
 
             // 画面が表示された旨を通知
-            Instance.UpdateProgressHandler(Instance);
+            Instance.HandleUpdateProgress(ProgressStatusInitView);
         }
 
         public static void OnCancel(FWUpdateProgressViewModel model)
@@ -86,6 +95,12 @@ namespace DesktopTool
 
             // TODO: 仮の実装です。
             Instance.NotifyTerminateInner(false);
+        }
+
+        private void HandleUpdateProgress(ProgressStatus status)
+        {
+            Status = status;
+            UpdateProgressHandler(this);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgress.cs
@@ -11,6 +11,7 @@ namespace DesktopTool
         {
             ProgressStatusNone = 0,
             ProgressStatusInitView,
+            ProgressStatusCancelClicked,
         };
 
         // このクラスのインスタンス
@@ -60,6 +61,12 @@ namespace DesktopTool
         //
         // 外部公開用
         //
+        public static void CloseForm(bool dialogResult)
+        {
+            // ファームウェア更新進捗画面を閉じる
+            Instance.NotifyTerminateInner(dialogResult);
+        }
+
         public static void SetMaxProgress(FWUpdateProgressViewModel model, int maxProgress)
         {
             // 進捗度の最大値を画面に反映させる
@@ -93,8 +100,8 @@ namespace DesktopTool
             // エラーメッセージを設定
             Instance.ErrorMessage = MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED;
 
-            // TODO: 仮の実装です。
-            Instance.NotifyTerminateInner(false);
+            // 中止ボタンがクリックされた旨を通知
+            Instance.HandleUpdateProgress(ProgressStatusCancelClicked);
         }
 
         private void HandleUpdateProgress(ProgressStatus status)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressViewModel.cs
@@ -55,7 +55,7 @@ namespace DesktopTool
         //
         private void OnButtonCloseClicked()
         {
-            FWUpdateProgress.OnCancel(this);
+            FWUpdateProgress.OnCancel();
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressViewModel.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressViewModel.cs
@@ -10,6 +10,7 @@ namespace DesktopTool
         private string remaining = null!;
         private int level = 0;
         private int maxLevel = 0;
+        private bool buttonCloseIsEnabled;
 
         public FWUpdateProgressViewModel()
         {
@@ -18,6 +19,7 @@ namespace DesktopTool
             Remaining = string.Empty;
             Level = 0;
             MaxLevel = 100;
+            ButtonCloseIsEnabled = false;
             try { FWUpdateProgress.InitView(this); } catch { }
         }
 
@@ -50,6 +52,12 @@ namespace DesktopTool
             set { maxLevel = value; NotifyPropertyChanged(nameof(MaxLevel)); }
         }
 
+        public bool ButtonCloseIsEnabled
+        {
+            get { return buttonCloseIsEnabled; }
+            set { buttonCloseIsEnabled = value; NotifyPropertyChanged(nameof(ButtonCloseIsEnabled)); }
+        }
+
         //
         // 内部処理
         //
@@ -79,6 +87,11 @@ namespace DesktopTool
         public void SetMaxLevel(int value)
         {
             MaxLevel = value;
+        }
+
+        public void EnableButtonClose(bool b)
+        {
+            ButtonCloseIsEnabled = b;
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressWindow.xaml
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateProgressWindow.xaml
@@ -12,6 +12,6 @@
     <Grid Height="150">
         <ProgressBar x:Name="levelIndicator" Value="{Binding Level}" Maximum="{Binding MaxLevel}" HorizontalAlignment="Center" Height="24" Margin="0,20,0,0" VerticalAlignment="Top" Width="350"/>
         <Label x:Name="labelRemaining" Content="{Binding Remaining}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,55,0,0" Width="350"/>
-        <Button x:Name="buttonClose" Content="中止" Command="{Binding ButtonCloseClicked}" HorizontalAlignment="Center" Margin="0,100,0,0" VerticalAlignment="Top" Height="25" Width="150"/>
+        <Button x:Name="buttonClose" Content="中止" Command="{Binding ButtonCloseClicked}" IsEnabled="{Binding ButtonCloseIsEnabled}" HorizontalAlignment="Center" Margin="0,100,0,0" VerticalAlignment="Top" Height="25" Width="150"/>
     </Grid>
 </Window>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -55,7 +55,7 @@ namespace DesktopTool
         private void OnConnectBLESMPTransport(BLESMPTransport sender)
         {
             // TODO: 仮の実装です。
-            sender.Disconnect();
+            DisconnectBLESMPTransport(sender);
             for (int i = 0; i < 30; i++) {
                 System.Threading.Thread.Sleep(100);
             }
@@ -121,8 +121,33 @@ namespace DesktopTool
                 return;
             }
 
+            // コールバックを登録
+            sender.RegisterResponseReceivedHandler(ResponseReceivedHandler);
+            sender.RegisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler);
+
             // 後続処理を実行
             OnConnectBLESMPTransport((BLESMPTransport)sender);
+        }
+
+        private void DisconnectBLESMPTransport(BLETransport sender)
+        {
+            // コールバックを解除
+            sender.UnregisterResponseReceivedHandler(ResponseReceivedHandler);
+            sender.UnregisterNotifyConnectionStatusHandler(NotifyConnectionStatusHandler);
+
+            // 接続を終了
+            sender.Disconnect();
+        }
+
+        //
+        // BLE SMPサービスのコールバック関数
+        //
+        private void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
+        {
+        }
+
+        private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
+        {
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -271,7 +271,14 @@ namespace DesktopTool
 
         private void DoResponseChangeImageUpdateMode(BLESMPTransport sender, byte[] responseData)
         {
-            // TODO: 仮の実装です。
+            // スロット照会情報を参照し、チェックでNGの場合は以降の処理を行わない
+            string errorMessage;
+            if (FWUpdateTransferUtil.CheckUploadedSlotInfo(responseData, out errorMessage) == false) {
+                TerminateCommand(sender, false, errorMessage);
+                return;
+            }
+
+            // 後続処理に移行
             OnResponseChangeImageUpdateMode(sender);
         }
     }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -1,0 +1,55 @@
+﻿using static DesktopTool.FWUpdateTransfer.TransferStatus;
+
+namespace DesktopTool
+{
+    internal class FWUpdateTransfer
+    {
+        // ステータス
+        public enum TransferStatus
+        {
+            TransferStatusNone = 0,
+            TransferStatusUpdateProgress,
+            TransferStatusCompleted,
+        };
+
+        // プロパティー
+        public FWUpdateImage UpdateImage { get; private set; }
+        public TransferStatus Status { get; private set; }
+        public int Progress { get; private set; }
+
+        // ファームウェア更新イメージ転送時のコールバックを保持
+        public delegate void FWUpdateImageTransferHandler(FWUpdateTransfer sender);
+        private event FWUpdateImageTransferHandler UpdateImageTransferHandler = null!;
+
+        public FWUpdateTransfer(FWUpdateImage updateImage)
+        {
+            UpdateImage = updateImage;
+            Status = TransferStatusNone;
+            Progress = 0;
+        }
+
+        //
+        // ファームウェア更新イメージ転送処理
+        //
+        public void Start(FWUpdateImageTransferHandler updateImageTransferHandler)
+        {
+            UpdateImageTransferHandler = updateImageTransferHandler;
+
+            // TODO: 仮の実装です。
+            for (int i = 0; i < 100; i++) {
+                Progress = i + 1;
+                HandleUpdateImageTransfer(TransferStatusUpdateProgress);
+                System.Threading.Thread.Sleep(100);
+            }
+
+            // TODO: 仮の実装です。
+            HandleUpdateImageTransfer(TransferStatusCompleted);
+        }
+
+        private void HandleUpdateImageTransfer(TransferStatus status)
+        {
+            Status = status;
+            UpdateImageTransferHandler(this);
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -8,6 +8,7 @@ namespace DesktopTool
         public enum TransferStatus
         {
             TransferStatusNone = 0,
+            TransferStatusStarted,
             TransferStatusUpdateProgress,
             TransferStatusCompleted,
         };
@@ -34,6 +35,9 @@ namespace DesktopTool
         public void Start(FWUpdateImageTransferHandler updateImageTransferHandler)
         {
             UpdateImageTransferHandler = updateImageTransferHandler;
+
+            // 転送処理開始を通知
+            HandleUpdateImageTransfer(TransferStatusStarted);
 
             // TODO: 仮の実装です。
             for (int i = 0; i < 100; i++) {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -64,6 +64,12 @@ namespace DesktopTool
 
         private void OnResponseGetSlotInfo(BLESMPTransport sender)
         {
+            // 転送処理に移行
+            DoRequestUploadImage(sender);
+        }
+
+        private void OnResponseUploadImage(BLESMPTransport sender)
+        {
             // TODO: 仮の実装です。
             DisconnectBLESMPTransport(sender);
             for (int i = 0; i < 30; i++) {
@@ -177,6 +183,9 @@ namespace DesktopTool
             if (sender.CommandName.Equals(nameof(DoRequestGetSlotInfo))) {
                 DoResponseGetSlotInfo((BLESMPTransport)sender, responseBytes);
             }
+            if (sender.CommandName.Equals(nameof(DoRequestUploadImage))) {
+                DoResponseUploadImage((BLESMPTransport)sender, responseBytes);
+            }
         }
 
         private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
@@ -201,8 +210,23 @@ namespace DesktopTool
                 return;
             }
 
-            // TODO: 仮の実装です。
+            // 後続処理に移行
             OnResponseGetSlotInfo(sender);
+        }
+        //
+        // イメージ転送
+        //
+        private void DoRequestUploadImage(BLESMPTransport sender)
+        {
+            // リクエストデータを送信
+            FWUpdateTransferParameter parameter = new FWUpdateTransferParameter(UpdateImage.UpdateImageData);
+            FWUpdateTransferUtil.SendRequestUploadImage(sender, nameof(DoRequestUploadImage), parameter);
+        }
+
+        private void DoResponseUploadImage(BLESMPTransport sender, byte[] responseData)
+        {
+            // 後続処理に移行
+            OnResponseUploadImage(sender);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -194,6 +194,13 @@ namespace DesktopTool
 
         private void DoResponseGetSlotInfo(BLESMPTransport sender, byte[] responseData)
         {
+            // スロット照会情報を参照し、チェックでNGの場合は以降の処理を行わない
+            string errorMessage;
+            if (FWUpdateTransferUtil.CheckSlotInfoResponse(responseData, UpdateImage.UpdateImageData.SHA256Hash, out errorMessage) == false) {
+                TerminateCommand(sender, false, errorMessage);
+                return;
+            }
+
             // TODO: 仮の実装です。
             OnResponseGetSlotInfo(sender);
         }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -139,11 +139,29 @@ namespace DesktopTool
             sender.Disconnect();
         }
 
+        private void TerminateCommand(BLETransport sender, bool success, string errorMessage)
+        {
+            // 切断処理
+            DisconnectBLESMPTransport((BLESMPTransport)sender);
+
+            // 失敗時は上位クラスに制御を戻す
+            if (success == false) {
+                ErrorMessage = errorMessage;
+                HandleUpdateImageTransfer(TransferStatusFailed);
+                return;
+            }
+        }
+
         //
         // BLE SMPサービスのコールバック関数
         //
         private void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
         {
+            // レスポンス受信失敗時はエラー扱い
+            if (success == false) {
+                TerminateCommand(sender, false, errorMessage);
+                return;
+            }
         }
 
         private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -86,9 +86,15 @@ namespace DesktopTool
             // 反映要求処理に移行
             DoRequestChangeImageUpdateMode(sender);
         }
-        
+
         private void OnResponseChangeImageUpdateMode(BLESMPTransport sender)
-        { 
+        {
+            // リセット要求処理に移行
+            DoRequestResetApplication(sender);
+        }
+
+        private void OnResponseResetApplication(BLESMPTransport sender) 
+        {
             // BLE接続を切断
             DisconnectBLESMPTransport(sender);
 
@@ -198,6 +204,10 @@ namespace DesktopTool
             }
             if (sender.CommandName.Equals(nameof(DoRequestChangeImageUpdateMode))) {
                 DoResponseChangeImageUpdateMode((BLESMPTransport)sender, responseBytes);
+                return;
+            }
+            if (sender.CommandName.Equals(nameof(DoRequestResetApplication))) {
+                DoResponseResetApplication((BLESMPTransport)sender, responseBytes);
             }
         }
 
@@ -294,6 +304,21 @@ namespace DesktopTool
 
             // 後続処理に移行
             OnResponseChangeImageUpdateMode(sender);
+        }
+
+        //
+        // リセット要求
+        //
+        private void DoRequestResetApplication(BLESMPTransport sender)
+        {
+            // リクエストデータを送信
+            FWUpdateTransferUtil.SendRequestResetApplication(sender, nameof(DoRequestResetApplication), TransferParameter);
+        }
+
+        private void DoResponseResetApplication(BLESMPTransport sender, byte[] responseData)
+        {
+            // 後続処理に移行
+            OnResponseResetApplication(sender);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -10,6 +10,7 @@ namespace DesktopTool
         {
             TransferStatusNone = 0,
             TransferStatusStarting,
+            TransferStatusPreprocess,
             TransferStatusStarted,
             TransferStatusUpdateProgress,
             TransferStatusCanceling,
@@ -45,7 +46,7 @@ namespace DesktopTool
         {
             UpdateImageTransferHandler = updateImageTransferHandler;
 
-            // 転送処理準備を通知
+            // 転送処理の前処理を通知
             HandleUpdateImageTransfer(TransferStatusStarting);
 
             // BLE SMPサービスに接続
@@ -54,6 +55,9 @@ namespace DesktopTool
 
         private void OnConnectBLESMPTransport(BLESMPTransport sender)
         {
+            // 転送処理準備を通知
+            HandleUpdateImageTransfer(TransferStatusPreprocess);
+
             // TODO: 仮の実装です。
             DisconnectBLESMPTransport(sender);
             for (int i = 0; i < 30; i++) {

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -8,6 +8,7 @@ namespace DesktopTool
         public enum TransferStatus
         {
             TransferStatusNone = 0,
+            TransferStatusStarting,
             TransferStatusStarted,
             TransferStatusUpdateProgress,
             TransferStatusCanceling,
@@ -37,6 +38,14 @@ namespace DesktopTool
         public void Start(FWUpdateImageTransferHandler updateImageTransferHandler)
         {
             UpdateImageTransferHandler = updateImageTransferHandler;
+
+            // 転送処理準備を通知
+            HandleUpdateImageTransfer(TransferStatusStarting);
+
+            // TODO: 仮の実装です。
+            for (int i = 0; i < 30; i++) {
+                System.Threading.Thread.Sleep(100);
+            }
 
             // 転送処理開始を通知
             HandleUpdateImageTransfer(TransferStatusStarted);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -78,7 +78,13 @@ namespace DesktopTool
 
         private void OnResponseUploadImage(BLESMPTransport sender)
         {
-            // TODO: 仮の実装です。
+            // 反映要求処理に移行
+            DoRequestChangeImageUpdateMode(sender);
+        }
+        
+        private void OnResponseChangeImageUpdateMode(BLESMPTransport sender)
+        { 
+            // BLE接続を切断
             DisconnectBLESMPTransport(sender);
 
             // 転送処理完了-->反映待機を通知
@@ -182,6 +188,9 @@ namespace DesktopTool
                 DoResponseUploadImage((BLESMPTransport)sender, responseBytes);
                 return;
             }
+            if (sender.CommandName.Equals(nameof(DoRequestChangeImageUpdateMode))) {
+                DoResponseChangeImageUpdateMode((BLESMPTransport)sender, responseBytes);
+            }
         }
 
         private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
@@ -249,6 +258,21 @@ namespace DesktopTool
                 // 後続処理に移行
                 OnResponseUploadImage(sender);
             }
+        }
+
+        //
+        // 反映要求
+        //
+        private void DoRequestChangeImageUpdateMode(BLESMPTransport sender)
+        {
+            // リクエストデータを送信
+            FWUpdateTransferUtil.SendRequestChangeImageUpdateMode(sender, nameof(DoRequestChangeImageUpdateMode), TransferParameter);
+        }
+
+        private void DoResponseChangeImageUpdateMode(BLESMPTransport sender, byte[] responseData)
+        {
+            // TODO: 仮の実装です。
+            OnResponseChangeImageUpdateMode(sender);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -101,14 +101,14 @@ namespace DesktopTool
             // 転送処理完了-->反映待機を通知
             HandleUpdateImageTransfer(TransferStatusWaitingUpdate);
 
-            // TODO: 仮の実装です。
+            // 反映待ち（リセットによるファームウェア再始動完了まで待機）
             for (int i = 0; i < FWUpdateConst.DFU_WAITING_SEC_ESTIMATED; i++) {
                 Progress = 100 + i + 1;
                 HandleUpdateImageTransfer(TransferStatusWaitingUpdateProgress);
-                System.Threading.Thread.Sleep(100);
+                System.Threading.Thread.Sleep(1000);
             }
 
-            // TODO: 仮の実装です。
+            // ファームウェア反映完了を通知
             HandleUpdateImageTransfer(TransferStatusCompleted);
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -13,6 +13,8 @@ namespace DesktopTool
             TransferStatusUpdateProgress,
             TransferStatusCanceling,
             TransferStatusCanceled,
+            TransferStatusWaitingUpdate,
+            TransferStatusWaitingUpdateProgress,
             TransferStatusCompleted,
         };
 
@@ -62,6 +64,16 @@ namespace DesktopTool
                     HandleUpdateImageTransfer(TransferStatusCanceled);
                     return;
                 }
+            }
+
+            // 転送処理完了-->反映待機を通知
+            HandleUpdateImageTransfer(TransferStatusWaitingUpdate);
+
+            // TODO: 仮の実装です。
+            for (int i = 0; i < FWUpdateConst.DFU_WAITING_SEC_ESTIMATED; i++) {
+                Progress = 100 + i + 1;
+                HandleUpdateImageTransfer(TransferStatusWaitingUpdateProgress);
+                System.Threading.Thread.Sleep(100);
             }
 
             // TODO: 仮の実装です。

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -58,6 +58,12 @@ namespace DesktopTool
             // 転送処理準備を通知
             HandleUpdateImageTransfer(TransferStatusPreprocess);
 
+            // スロット照会を実行
+            DoRequestGetSlotInfo(sender);
+        }
+
+        private void OnResponseGetSlotInfo(BLESMPTransport sender)
+        {
             // TODO: 仮の実装です。
             DisconnectBLESMPTransport(sender);
             for (int i = 0; i < 30; i++) {
@@ -166,10 +172,30 @@ namespace DesktopTool
                 TerminateCommand(sender, false, errorMessage);
                 return;
             }
+
+            // 後続処理を判定
+            if (sender.CommandName.Equals(nameof(DoRequestGetSlotInfo))) {
+                DoResponseGetSlotInfo((BLESMPTransport)sender, responseBytes);
+            }
         }
 
         private void NotifyConnectionStatusHandler(BLETransport sender, bool connected)
         {
+        }
+
+        //
+        // スロット照会
+        //
+        private static void DoRequestGetSlotInfo(BLESMPTransport sender)
+        {
+            // リクエストデータを送信
+            FWUpdateTransferUtil.SendRequestGetSlotInfo(sender, nameof(DoRequestGetSlotInfo));
+        }
+
+        private void DoResponseGetSlotInfo(BLESMPTransport sender, byte[] responseData)
+        {
+            // TODO: 仮の実装です。
+            OnResponseGetSlotInfo(sender);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -1,5 +1,4 @@
-﻿using AppCommon;
-using static DesktopTool.BLEDefines;
+﻿using static DesktopTool.BLEDefines;
 using static DesktopTool.FWUpdateTransfer.TransferStatus;
 
 namespace DesktopTool

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -74,6 +74,9 @@ namespace DesktopTool
             // 転送処理開始を通知
             HandleUpdateImageTransfer(TransferStatusStarted);
 
+            // ログ出力を一時停止
+            sender.NoOutputLog = true;
+
             // 転送処理に移行
             DoRequestUploadImage(sender);
         }
@@ -153,6 +156,9 @@ namespace DesktopTool
 
         private void TerminateCommand(BLETransport sender, bool success, string errorMessage)
         {
+            // ログ出力を再開
+            sender.NoOutputLog = false;
+
             // 切断処理
             DisconnectBLESMPTransport((BLESMPTransport)sender);
 
@@ -257,6 +263,9 @@ namespace DesktopTool
                 DoRequestUploadImage(sender);
 
             } else {
+                // ログ出力を再開
+                sender.NoOutputLog = false;
+
                 // 後続処理に移行
                 OnResponseUploadImage(sender);
             }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -1,4 +1,5 @@
-﻿using static DesktopTool.BLEDefines;
+﻿using AppCommon;
+using static DesktopTool.BLEDefines;
 using static DesktopTool.FWUpdateTransfer.TransferStatus;
 
 namespace DesktopTool
@@ -15,6 +16,7 @@ namespace DesktopTool
             TransferStatusUpdateProgress,
             TransferStatusCanceling,
             TransferStatusCanceled,
+            TransferStatusUploadCompleted,
             TransferStatusWaitingUpdate,
             TransferStatusWaitingUpdateProgress,
             TransferStatusCompleted,
@@ -277,6 +279,9 @@ namespace DesktopTool
                 TerminateCommand(sender, false, errorMessage);
                 return;
             }
+
+            // 更新イメージ転送成功を通知
+            HandleUpdateImageTransfer(TransferStatusUploadCompleted);
 
             // 後続処理に移行
             OnResponseChangeImageUpdateMode(sender);

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -10,6 +10,8 @@ namespace DesktopTool
             TransferStatusNone = 0,
             TransferStatusStarted,
             TransferStatusUpdateProgress,
+            TransferStatusCanceling,
+            TransferStatusCanceled,
             TransferStatusCompleted,
         };
 
@@ -44,10 +46,23 @@ namespace DesktopTool
                 Progress = i + 1;
                 HandleUpdateImageTransfer(TransferStatusUpdateProgress);
                 System.Threading.Thread.Sleep(100);
+
+                // TODO: 仮の実装です。
+                // 処理進捗画面でCancelボタンが押下された時
+                if (Status == TransferStatusCanceling) {
+                    HandleUpdateImageTransfer(TransferStatusCanceled);
+                    return;
+                }
             }
 
             // TODO: 仮の実装です。
             HandleUpdateImageTransfer(TransferStatusCompleted);
+        }
+
+        public void Cancel()
+        {
+            // ファームウェア更新イメージ転送処理を中止させる
+            Status = TransferStatusCanceling;
         }
 
         private void HandleUpdateImageTransfer(TransferStatus status)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -187,9 +187,11 @@ namespace DesktopTool
             // 後続処理を判定
             if (sender.CommandName.Equals(nameof(DoRequestGetSlotInfo))) {
                 DoResponseGetSlotInfo((BLESMPTransport)sender, responseBytes);
+                return;
             }
             if (sender.CommandName.Equals(nameof(DoRequestUploadImage))) {
                 DoResponseUploadImage((BLESMPTransport)sender, responseBytes);
+                return;
             }
         }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransfer.cs
@@ -26,6 +26,7 @@ namespace DesktopTool
         public TransferStatus Status { get; private set; }
         public int Progress { get; private set; }
         public string ErrorMessage { get; private set; }
+        public FWUpdateTransferParameter TransferParameter { get; private set; }
 
         // ファームウェア更新イメージ転送時のコールバックを保持
         public delegate void FWUpdateImageTransferHandler(FWUpdateTransfer sender);
@@ -37,6 +38,7 @@ namespace DesktopTool
             Status = TransferStatusNone;
             Progress = 0;
             ErrorMessage = string.Empty;
+            TransferParameter = new FWUpdateTransferParameter(updateImage.UpdateImageData);
         }
 
         //
@@ -64,6 +66,9 @@ namespace DesktopTool
 
         private void OnResponseGetSlotInfo(BLESMPTransport sender)
         {
+            // 転送済みバイト数を事前にクリア
+            TransferParameter.ImageBytesSent = 0;
+
             // 転送処理に移行
             DoRequestUploadImage(sender);
         }
@@ -219,8 +224,7 @@ namespace DesktopTool
         private void DoRequestUploadImage(BLESMPTransport sender)
         {
             // リクエストデータを送信
-            FWUpdateTransferParameter parameter = new FWUpdateTransferParameter(UpdateImage.UpdateImageData);
-            FWUpdateTransferUtil.SendRequestUploadImage(sender, nameof(DoRequestUploadImage), parameter);
+            FWUpdateTransferUtil.SendRequestUploadImage(sender, nameof(DoRequestUploadImage), TransferParameter);
         }
 
         private void DoResponseUploadImage(BLESMPTransport sender, byte[] responseData)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -14,8 +14,6 @@
 
         public const int GRP_OS_MGMT = 0;
         public const int CMD_OS_MGMT_RESET = 5;
-
-        public const int SMP_HEADER_SIZE = 8;
     }
 
     internal class FWUpdateTransferUtil

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -300,5 +300,29 @@ namespace DesktopTool
             byte[] terminator = { 0xff };
             return body.Concat(terminator).ToArray();
         }
+
+        //
+        // 反映要求（応答）
+        //
+        public static bool CheckUploadedSlotInfo(byte[] responseData, out string errorMessage)
+        {
+            // メッセージの初期化
+            errorMessage = string.Empty;
+
+            // CBORをデコードしてスロット照会情報を抽出
+            FWUpdateCBORDecoder decoder = new FWUpdateCBORDecoder();
+            if (decoder.DecodeSlotInfo(responseData) == false) {
+                errorMessage = MSG_FW_UPDATE_SUB_PROCESS_FAILED;
+                return false;
+            }
+
+            // スロット情報の代わりに rc が設定されている場合はエラー
+            byte rc = decoder.ResultInfo.Rc;
+            if (rc != 0) {
+                errorMessage = string.Format(MSG_FW_UPDATE_PROCESS_IMAGE_INSTALL_FAILED_WITH_RC, rc);
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -1,4 +1,6 @@
-﻿namespace DesktopTool
+﻿using static DesktopTool.FWUpdateTransferConst;
+
+namespace DesktopTool
 {
     internal class FWUpdateTransferConst
     {
@@ -39,6 +41,20 @@
             // レスポンスヘッダーの３・４バイト目からデータ長を抽出
             int totalSize = ((responseData[2] << 8) & 0xff00) + (responseData[3] & 0x00ff);
             return totalSize;
+        }
+
+        //
+        // スロット照会
+        //
+        public static void SendRequestGetSlotInfo(BLESMPTransport sender, string commandName)
+        {
+            // リクエストデータを生成
+            byte[] bodyBytes = new byte[] { 0xbf, 0xff };
+            ushort len = (ushort)bodyBytes.Length;
+            byte[] headerBytes = BuildSMPHeader(OP_READ_REQ, 0x00, len, GRP_IMG_MGMT, 0x00, CMD_IMG_MGMT_STATE);
+
+            // リクエストデータを送信
+            sender.SendSMPRequestData(commandName, bodyBytes, headerBytes);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -1,0 +1,21 @@
+﻿namespace DesktopTool
+{
+    internal class FWUpdateTransferUtil
+    {
+        //
+        // BLE SMPサービス関連
+        //
+        public static byte[] BuildSMPHeader(byte op, byte flags, ushort len, ushort group, byte seq, byte id_int)
+        {
+            byte[] header = {
+                op,
+                flags,
+                (byte)(len >> 8),   (byte)(len & 0xff),
+                (byte)(group >> 8), (byte)(group & 0xff),
+                seq,
+                id_int
+            };
+            return header;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -1,5 +1,23 @@
 ﻿namespace DesktopTool
 {
+    internal class FWUpdateTransferConst
+    {
+        //
+        // SMPトランザクションで使用する定義
+        //
+        public const int OP_READ_REQ = 0;
+        public const int OP_WRITE_REQ = 2;
+
+        public const int GRP_IMG_MGMT = 1;
+        public const int CMD_IMG_MGMT_STATE = 0;
+        public const int CMD_IMG_MGMT_UPLOAD = 1;
+
+        public const int GRP_OS_MGMT = 0;
+        public const int CMD_OS_MGMT_RESET = 5;
+
+        public const int SMP_HEADER_SIZE = 8;
+    }
+
     internal class FWUpdateTransferUtil
     {
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -35,5 +35,12 @@
             };
             return header;
         }
+
+        public static int GetSMPResponseBodySize(byte[] responseData)
+        {
+            // レスポンスヘッダーの３・４バイト目からデータ長を抽出
+            int totalSize = ((responseData[2] << 8) & 0xff00) + (responseData[3] & 0x00ff);
+            return totalSize;
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -230,5 +230,32 @@ namespace DesktopTool
             // 転送イメージを連結して戻す
             return bodyBytes.Concat(sendData).ToArray();
         }
+
+        //
+        // イメージ転送（応答）
+        //
+        public static bool CheckUploadResultInfo(FWUpdateTransferParameter parameter, byte[] responseData, out string errorMessage)
+        {
+            // メッセージの初期化
+            errorMessage = string.Empty;
+
+            // CBORをデコードして転送結果情報を抽出
+            FWUpdateCBORDecoder decoder = new FWUpdateCBORDecoder();
+            if (decoder.DecodeUploadResultInfo(responseData) == false) {
+                errorMessage = MSG_FW_UPDATE_SUB_PROCESS_FAILED;
+                return false;
+            }
+
+            // 転送結果情報の rc が設定されている場合はエラー
+            byte rc = decoder.ResultInfo.Rc;
+            if (rc != 0) {
+                errorMessage = string.Format(MSG_FW_UPDATE_PROCESS_TRANSFER_FAILED_WITH_RC, rc);
+                return false;
+            }
+
+            // 転送結果情報の off 値を転送済みバイト数に設定
+            parameter.ImageBytesSent = (int)decoder.ResultInfo.Off;
+            return true;
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -1,4 +1,8 @@
-﻿using static DesktopTool.FunctionMessage;
+﻿using AppCommon;
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using static DesktopTool.FunctionMessage;
 using static DesktopTool.FWUpdateTransferConst;
 
 namespace DesktopTool
@@ -104,6 +108,127 @@ namespace DesktopTool
                 return false;
             }
             return true;
+        }
+
+        //
+        // イメージ転送
+        //
+        public static void SendRequestUploadImage(BLESMPTransport sender, string commandName, FWUpdateTransferParameter parameter)
+        {
+            // リクエストデータを生成
+            byte[] bodyBytes = GenerateBodyForRequestUploadImage(parameter);
+            ushort len = (ushort)bodyBytes.Length;
+            byte[] headerBytes = BuildSMPHeader(OP_WRITE_REQ, 0x00, len, GRP_IMG_MGMT, 0x00, CMD_IMG_MGMT_UPLOAD);
+
+            // リクエストデータを送信
+            sender.SendSMPRequestData(commandName, bodyBytes, headerBytes);
+        }
+
+        public static byte[] GenerateBodyForRequestUploadImage(FWUpdateTransferParameter Parameter)
+        {
+            // リクエストデータ
+            byte[] body = { 0xbf };
+
+            // 転送元データ長
+            uint bytesTotal = (uint)Parameter.UpdateImageData.NRF53AppBinSize;
+
+            if (Parameter.ImageBytesSent == 0) {
+                // 初回呼び出しの場合、イメージ長を設定
+                body = body.Concat(GenerateLenBytes(bytesTotal)).ToArray();
+
+                // イメージのハッシュ値を設定
+                body = body.Concat(GenerateSHA256HashData(Parameter.UpdateImageData.NRF53AppBin)).ToArray();
+            }
+
+            // 転送済みバイト数を設定
+            body = body.Concat(GenerateOffBytes(Parameter.ImageBytesSent)).ToArray();
+
+            // 転送イメージを連結（データ本体が240バイトに収まるよう、上限サイズを事前計算）
+            int remainingSize = 240 - body.Length - 1;
+            body = body.Concat(GenerateDataBytes(Parameter.UpdateImageData.NRF53AppBin, Parameter.ImageBytesSent, remainingSize)).ToArray();
+
+            // 終端文字を設定して戻す
+            byte[] terminator = { 0xff };
+            return body.Concat(terminator).ToArray();
+        }
+
+        private static byte[] GenerateLenBytes(uint bytesTotal)
+        {
+            // イメージ長を設定
+            byte[] lenBytes = {
+                0x63, 0x6c, 0x65, 0x6e, 0x1a, 0x00, 0x00, 0x00, 0x00
+            };
+            AppUtil.ConvertUint32ToBEBytes(bytesTotal, lenBytes, 5);
+            return lenBytes;
+        }
+
+        private static byte[] GenerateSHA256HashData(byte[] data)
+        {
+            // イメージのハッシュ値を計算
+            SHA256 sha = SHA256.Create();
+            byte[] hash = sha.ComputeHash(data);
+
+            // イメージのハッシュ値を設定
+            byte[] shaBytes = {
+                0x63, 0x73, 0x68, 0x61, 0x43, 0x00, 0x00, 0x00,
+            };
+
+            // 指定領域から３バイト分の領域に、SHA-256ハッシュの先頭３バイト分を設定
+            for (int i = 0; i < 3; i++) {
+                shaBytes[i + 5] = hash[i];
+            }
+            return shaBytes;
+        }
+
+        private static byte[] GenerateOffBytes(int bytesSent)
+        {
+            // 転送済みバイト数を設定
+            byte[] offBytes = {
+                0x63, 0x6f, 0x66, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00
+            };
+            int len = offBytes.Length;
+            if (bytesSent == 0) {
+                len = 5;
+
+            } else if (bytesSent < 0x100) {
+                offBytes[4] = 0x18;
+                offBytes[5] = (byte)bytesSent;
+                len = 6;
+
+            } else if (bytesSent < 0x10000) {
+                offBytes[4] = 0x19;
+                AppUtil.ConvertUint16ToBEBytes((UInt16)bytesSent, offBytes, 5);
+                len = 7;
+
+            } else {
+                offBytes[4] = 0x1a;
+                AppUtil.ConvertUint32ToBEBytes((UInt32)bytesSent, offBytes, 5);
+            }
+
+            // 不要な末尾バイトを除去して戻す
+            byte[] offData = offBytes.Take(len).ToArray();
+            return offData;
+        }
+
+        private static byte[] GenerateDataBytes(byte[] imageData, int bytesSent, int remaining)
+        {
+            // 転送バイト数を設定
+            byte[] bodyBytes = {
+                0x64, 0x64, 0x61, 0x74, 0x61, 0x58, 0x00
+            };
+
+            // 転送バイト数
+            int bytesToSend = remaining - bodyBytes.Length;
+            if (bytesToSend > imageData.Length - bytesSent) {
+                bytesToSend = imageData.Length - bytesSent;
+            }
+            bodyBytes[6] = (byte)bytesToSend;
+
+            // 転送イメージを抽出
+            byte[] sendData = imageData.Skip(bytesSent).Take(bytesToSend).ToArray();
+
+            // 転送イメージを連結して戻す
+            return bodyBytes.Concat(sendData).ToArray();
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -324,5 +324,19 @@ namespace DesktopTool
             }
             return true;
         }
+
+        //
+        // リセット要求
+        //
+        public static void SendRequestResetApplication(BLESMPTransport sender, string commandName, FWUpdateTransferParameter parameter)
+        {
+            // リクエストデータを生成
+            byte[] bodyBytes = new byte[] { 0xbf, 0xff };
+            ushort len = (ushort)bodyBytes.Length;
+            byte[] headerBytes = BuildSMPHeader(OP_WRITE_REQ, 0x00, len, GRP_OS_MGMT, 0x00, CMD_OS_MGMT_RESET);
+
+            // リクエストデータを送信
+            sender.SendSMPRequestData(commandName, bodyBytes, headerBytes);
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -23,7 +23,7 @@ namespace DesktopTool
         public const int CMD_OS_MGMT_RESET = 5;
 
         // イメージ反映モード　true＝テストモード[Swap type: test]、false＝通常モード[Swap type: perm]
-        public const bool IMAGE_UPDATE_TEST_MODE = true;
+        public const bool IMAGE_UPDATE_TEST_MODE = false;
     }
 
     internal class FWUpdateTransferParameter

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateTransferUtil.cs
@@ -19,6 +19,21 @@ namespace DesktopTool
         public const int CMD_OS_MGMT_RESET = 5;
     }
 
+    internal class FWUpdateTransferParameter
+    {
+        // 転送済みバイト数を保持
+        public int ImageBytesSent { get; set; }
+
+        // 更新イメージを保持
+        public FWUpdateImageData UpdateImageData { get; set; }
+
+        public FWUpdateTransferParameter(FWUpdateImageData updateImageData) 
+        { 
+            ImageBytesSent = 0;
+            UpdateImageData = updateImageData;
+        }
+    }
+
     internal class FWUpdateTransferUtil
     {
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersion.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersion.cs
@@ -1,5 +1,6 @@
 ﻿using AppCommon;
 using System.Text;
+using static DesktopTool.BLEDefines;
 using static DesktopTool.FunctionDefines;
 using static DesktopTool.FunctionMessage;
 
@@ -41,7 +42,7 @@ namespace DesktopTool
             NotifyResponseQuery += notifyResponseQueryHandler;
 
             // BLEデバイスに接続
-            new BLETransport().Connect(OnNotifyConnection);
+            new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
         }
 
         private void OnNotifyConnection(BLETransport sender, bool success, string errorMessage)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersion.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWVersion.cs
@@ -42,7 +42,7 @@ namespace DesktopTool
             NotifyResponseQuery += notifyResponseQueryHandler;
 
             // BLEデバイスに接続
-            new BLETransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
+            new BLEU2FTransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
         }
 
         private void OnNotifyConnection(BLETransport sender, bool success, string errorMessage)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -53,6 +53,7 @@
         public const string MSG_FW_UPDATE_PROMPT_START_PROCESS = "OKボタンをクリックすると、\nファームウェア更新処理が開始されます。\n\n処理が完了するまでは、BLEデバイスの\n電源をOnにしたままにして下さい。";
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
+        public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";
         public const string MSG_FW_UPDATE_VERSION_SUCCESS = "ファームウェアのバージョンが{0}に更新されました。";
         public const string MSG_FW_UPDATE_VERSION_FAIL = "ファームウェアのバージョンを{0}に更新できませんでした。";
         public const string MSG_FW_UPDATE_GET_IMAGE_VERSION_FROM_CONTEXT_FAIL = "ファームウェア更新イメージのバージョンを共有情報から取得できませんでした。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -55,6 +55,7 @@
         public const string MSG_FW_UPDATE_PROMPT_START_PROCESS = "OKボタンをクリックすると、\nファームウェア更新処理が開始されます。\n\n処理が完了するまでは、BLEデバイスの\n電源をOnにしたままにして下さい。";
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
+        public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE = "更新ファームウェアを転送中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
         public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";
         public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -48,8 +48,10 @@
         public const string MSG_FW_UPDATE_FUNC_NOT_AVAILABLE = "ファームウェア更新機能が利用できません。";
         public const string MSG_FW_UPDATE_IMAGE_FILE_NOT_EXIST = "ファームウェア更新イメージファイルが存在しません。";
         public const string MSG_FW_UPDATE_VERSION_UNKNOWN = "ファームウェア更新イメージファイルのバージョンが不明です。";
+        public const string MSG_FW_UPDATE_CURRENT_VERSION_CONFIRM = "ファームウェアの現在バージョンを確認中です。";
         public const string MSG_FW_UPDATE_CURRENT_VERSION_UNKNOWN = "ファームウェアの現在バージョンが不明です。";
         public const string MSG_FW_UPDATE_CURRENT_VERSION_ALREADY_NEW = "ファームウェア (現在のバージョン: {0}) を、バージョン{1}に更新することはできません。";
+        public const string MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION = "ファームウェア (現在のバージョン: {0}) を、バージョン{1}に更新します。";
         public const string MSG_FW_UPDATE_PROMPT_START_PROCESS = "OKボタンをクリックすると、\nファームウェア更新処理が開始されます。\n\n処理が完了するまでは、BLEデバイスの\n電源をOnにしたままにして下さい。";
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -47,6 +47,7 @@
         // ファームウェア更新
         public const string MSG_FW_UPDATE_FUNC_NOT_AVAILABLE = "ファームウェア更新機能が利用できません。";
         public const string MSG_FW_UPDATE_IMAGE_FILE_NOT_EXIST = "ファームウェア更新イメージファイルが存在しません。";
+        public const string MSG_FW_UPDATE_IMAGE_ALREADY_INSTALLED = "更新ファームウェアが既に導入済みなので、ファームウェア更新処理を続行できません。";
         public const string MSG_FW_UPDATE_VERSION_UNKNOWN = "ファームウェア更新イメージファイルのバージョンが不明です。";
         public const string MSG_FW_UPDATE_CURRENT_VERSION_CONFIRM = "ファームウェアの現在バージョンを確認中です。";
         public const string MSG_FW_UPDATE_CURRENT_VERSION_UNKNOWN = "ファームウェアの現在バージョンが不明です。";
@@ -55,6 +56,7 @@
         public const string MSG_FW_UPDATE_PROMPT_START_PROCESS = "OKボタンをクリックすると、\nファームウェア更新処理が開始されます。\n\n処理が完了するまでは、BLEデバイスの\n電源をOnにしたままにして下さい。";
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
+        public const string MSG_FW_UPDATE_SUB_PROCESS_FAILED = "ファームウェア更新機能の内部処理が失敗しました。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE = "更新ファームウェアを転送中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
         public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -54,6 +54,7 @@
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
+        public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";
         public const string MSG_FW_UPDATE_VERSION_SUCCESS = "ファームウェアのバージョンが{0}に更新されました。";
         public const string MSG_FW_UPDATE_VERSION_FAIL = "ファームウェアのバージョンを{0}に更新できませんでした。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -60,6 +60,7 @@
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE = "更新ファームウェアを転送中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_FAILED_WITH_RC = "更新ファームウェアの転送中に不明なエラー（rc={0}）が発生しました。";
+        public const string MSG_FW_UPDATE_PROCESS_IMAGE_INSTALL_FAILED_WITH_RC = "更新ファームウェアの転送後に不明なエラー（rc={0}）が発生しました。";
         public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";
         public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -54,6 +54,7 @@
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
+        public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";
         public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";
         public const string MSG_FW_UPDATE_VERSION_SUCCESS = "ファームウェアのバージョンが{0}に更新されました。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -59,6 +59,7 @@
         public const string MSG_FW_UPDATE_SUB_PROCESS_FAILED = "ファームウェア更新機能の内部処理が失敗しました。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE = "更新ファームウェアを転送中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
+        public const string MSG_FW_UPDATE_PROCESS_TRANSFER_FAILED_WITH_RC = "更新ファームウェアの転送中に不明なエラー（rc={0}）が発生しました。";
         public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";
         public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -53,6 +53,7 @@
         public const string MSG_FW_UPDATE_PROMPT_START_PROCESS = "OKボタンをクリックすると、\nファームウェア更新処理が開始されます。\n\n処理が完了するまでは、BLEデバイスの\n電源をOnにしたままにして下さい。";
         public const string MSG_FW_UPDATE_PROCESSING = "ファームウェアを更新しています";
         public const string MSG_FW_UPDATE_PRE_PROCESS = "ファームウェア更新の前処理中です";
+        public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_CANCELED = "更新ファームウェアの転送をユーザーが中止しました。";
         public const string MSG_FW_UPDATE_VERSION_SUCCESS = "ファームウェアのバージョンが{0}に更新されました。";
         public const string MSG_FW_UPDATE_VERSION_FAIL = "ファームウェアのバージョンを{0}に更新できませんでした。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -60,6 +60,7 @@
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE = "更新ファームウェアを転送中です。";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_IMAGE_FORMAT = "更新ファームウェアを転送中（{0}％）";
         public const string MSG_FW_UPDATE_PROCESS_TRANSFER_FAILED_WITH_RC = "更新ファームウェアの転送中に不明なエラー（rc={0}）が発生しました。";
+        public const string MSG_FW_UPDATE_PROCESS_TRANSFER_SUCCESS = "更新ファームウェアの転送が完了しました。";
         public const string MSG_FW_UPDATE_PROCESS_IMAGE_INSTALL_FAILED_WITH_RC = "更新ファームウェアの転送後に不明なエラー（rc={0}）が発生しました。";
         public const string MSG_FW_UPDATE_PROCESS_WAITING_UPDATE = "転送された更新ファームウェアの反映を待機中です。";
         public const string MSG_FW_UPDATE_PROCESS_CONFIRM_VERSION = "転送された更新ファームウェアのバージョンを確認中です。";

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionUtil.cs
@@ -1,8 +1,8 @@
 ﻿using AppCommon;
 using System;
 using System.Windows;
-using static DesktopTool.FunctionMessage;
 using static DesktopTool.FunctionDefines;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
@@ -16,9 +16,7 @@ namespace DesktopTool
             if (EnableButtonClick == null) {
                 return;
             }
-            Application.Current.Dispatcher.Invoke(new Action(() => {
-                EnableButtonClick(isEnabled);
-            }));
+            Application.Current.Dispatcher.Invoke(EnableButtonClick, isEnabled);
         }
 
         public static void DisplayTextOnApp(string text, Action<string> DisplayTextAction)
@@ -26,9 +24,7 @@ namespace DesktopTool
             if (DisplayTextAction == null) {
                 return;
             }
-            Application.Current.Dispatcher.Invoke(new Action(() => {
-                DisplayTextAction(text);
-            }));
+            Application.Current.Dispatcher.Invoke(DisplayTextAction, text);
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/ToolCommon/ToolDoProcess.cs
@@ -114,14 +114,18 @@ namespace DesktopTool
 
         protected void LogAndShowInfoMessage(string infoMessage)
         {
-            AppLogUtil.OutputLogInfo(infoMessage);
-            FunctionUtil.DisplayTextOnApp(infoMessage, ViewModel.AppendStatusText);
+            if (infoMessage.Length > 0) {
+                AppLogUtil.OutputLogInfo(infoMessage);
+                FunctionUtil.DisplayTextOnApp(infoMessage, ViewModel.AppendStatusText);
+            }
         }
 
         protected void LogAndShowErrorMessage(string errorMessage)
         {
-            AppLogUtil.OutputLogError(errorMessage);
-            FunctionUtil.DisplayTextOnApp(errorMessage, ViewModel.AppendStatusText);
+            if (errorMessage.Length > 0) {
+                AppLogUtil.OutputLogError(errorMessage);
+                FunctionUtil.DisplayTextOnApp(errorMessage, ViewModel.AppendStatusText);
+            }
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -15,6 +15,8 @@
         public const int U2F_BLE_CONT_HEADER_LEN = 1;
         public const int U2F_BLE_FRAME_LEN = 64;
 
+        public const int SMP_HEADER_SIZE = 8;
+
         // 性能関連
         public const int U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC = 3000;
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -7,6 +7,9 @@
         public const string U2F_CONTROL_POINT_CHAR_UUID_STR = "F1D0FFF1-DEAA-ECEE-B42F-C9BA7ED623BB";
         public const string U2F_STATUS_CHAR_UUID_STR = "F1D0FFF2-DEAA-ECEE-B42F-C9BA7ED623BB";
 
+        public const string BLE_SMP_SERVICE_UUID_STR = "8D53DC1D-1DB7-4CD3-868B-8A527460AA84";
+        public const string BLE_SMP_CHARACT_UUID_STR = "DA2E7828-FBCE-4E01-AE9E-261174997C48";
+
         // BLEフレームに関する定数
         public const int U2F_BLE_INIT_HEADER_LEN = 3;
         public const int U2F_BLE_CONT_HEADER_LEN = 1;

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEDefines.cs
@@ -19,6 +19,7 @@
 
         // 性能関連
         public const int U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC = 3000;
+        public const int SMP_BLE_SERVICE_RESP_TIMEOUT_MSEC = 10000;
 
         // 定数
         public const uint WINDOWS_ERROR_NO_MORE_FILES = 0x80650012;

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPeripheralScanner.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEPeripheralScanner.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Windows.Devices.Bluetooth.Advertisement;
 using Windows.Devices.Radios;
 using Windows.Storage.Streams;
-using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;
 
 namespace DesktopTool
@@ -13,29 +12,20 @@ namespace DesktopTool
     internal class BLEPeripheralScannerParam
     {
         public Guid ServiceUUID { get; set; }
-        public Guid CharactForWriteUUID { get; set; }
-        public Guid CharactForReadUUID { get; set; }
         public ulong BluetoothAddress { get; set; }
         public byte[] ServiceDataField { get; set; }
         public bool FIDOServiceDataFieldFound { get; set; }
         public bool BLEPeripheralFound { get; set; }
         public bool ConnectOnly { get; set; }
 
-        public BLEPeripheralScannerParam(string serviceUUIDString, string charactForWriteUUIDString, string charactForReadUUIDString)
+        public BLEPeripheralScannerParam(string serviceUUIDString)
         {
             ServiceUUID = new Guid(serviceUUIDString);
-            CharactForWriteUUID = new Guid(charactForWriteUUIDString);
-            CharactForReadUUID = new Guid(charactForReadUUIDString);
             BluetoothAddress = 0;
             ServiceDataField = Array.Empty<byte>();
             FIDOServiceDataFieldFound = false;
             BLEPeripheralFound = false;
             ConnectOnly = false;
-        }
-
-        public static BLEPeripheralScannerParam PrepareParameterForFIDO()
-        {
-            return new BLEPeripheralScannerParam(U2F_BLE_SERVICE_UUID_STR, U2F_STATUS_CHAR_UUID_STR, U2F_CONTROL_POINT_CHAR_UUID_STR);
         }
     }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLESMPService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLESMPService.cs
@@ -1,0 +1,30 @@
+﻿using Windows.Devices.Bluetooth.GenericAttributeProfile;
+using static DesktopTool.BLEDefines;
+
+namespace DesktopTool
+{
+    internal class BLESMPService : BLEService
+    {
+        // 応答タイムアウトを設定
+        protected override int TimeoutMsecsOfResponseTimer()
+        {
+            return SMP_BLE_SERVICE_RESP_TIMEOUT_MSEC;
+        }
+
+        //
+        // 送信処理
+        // 
+        public override void SendFrame(byte[] frameBytes)
+        {
+            // 書込みオプションを設定
+            GattWriteOption writeOption = GattWriteOption.WriteWithoutResponse;
+            GattCharacteristic characteristicForSend = BLEservice.GetCharacteristics(Parameter.CharacteristicForSend)[0];
+            if ((characteristicForSend.CharacteristicProperties & GattCharacteristicProperties.WriteWithoutResponse) == 0) {
+                writeOption = GattWriteOption.WriteWithResponse;
+            }
+
+            // 送信
+            SendFrame(characteristicForSend, writeOption, frameBytes);
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -33,7 +33,7 @@ namespace DesktopTool
         public BLEService()
         {
             // 応答タイムアウト発生時のイベントを登録
-            ResponseTimer = new CommonTimer("BLEService", U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC);
+            ResponseTimer = new CommonTimer(GetType().Name, U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC);
             ResponseTimer.CommandTimeoutEvent += OnResponseTimerElapsed;
             FreeResources();
         }
@@ -128,7 +128,7 @@ namespace DesktopTool
                 foreach (var gattService in gattServices.Services) {
                     if (gattService.Uuid.Equals(parameter.ServiceUUID)) {
                         BLEservice = gattService;
-                        AppLogUtil.OutputLogDebug(string.Format("  FIDO BLE service found [{0}]", gattService.Device.Name));
+                        AppLogUtil.OutputLogDebug(string.Format("  BLE service found [{0}]", gattService.Device.Name));
                     }
                 }
 
@@ -233,7 +233,7 @@ namespace DesktopTool
                     }
 
                 } else {
-                    AppLogUtil.OutputLogDebug(string.Format("BLEService.SendFrame: U2F control point characteristic is null"));
+                    AppLogUtil.OutputLogDebug(string.Format("BLEService.SendFrame: characteristic for send is null"));
                     OnFrameReceived(false, MSG_REQUEST_SEND_FAILED, Array.Empty<byte>());
                 }
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -30,10 +30,16 @@ namespace DesktopTool
         // 応答タイムアウト監視用タイマー
         private readonly CommonTimer ResponseTimer = null!;
 
+        // 応答タイムアウトを設定
+        protected virtual int TimeoutMsecsOfResponseTimer()
+        {
+            return U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC;
+        }
+
         public BLEService()
         {
             // 応答タイムアウト発生時のイベントを登録
-            ResponseTimer = new CommonTimer(GetType().Name, U2F_BLE_SERVICE_RESP_TIMEOUT_MSEC);
+            ResponseTimer = new CommonTimer(GetType().Name, TimeoutMsecsOfResponseTimer());
             ResponseTimer.CommandTimeoutEvent += OnResponseTimerElapsed;
             FreeResources();
         }
@@ -43,9 +49,9 @@ namespace DesktopTool
         //
         // サービスをディスカバーできたデバイスを保持
         private BluetoothLEDevice BluetoothLEDevice = null!;
-        private GattDeviceService BLEservice = null!;
+        protected GattDeviceService BLEservice = null!;
         private GattCharacteristic CharacteristicForNotify = null!;
-        private BLEServiceParam Parameter = null!;
+        protected BLEServiceParam Parameter = null!;
 
         // ステータスを保持
         private GattCommunicationStatus CommunicationStatus;
@@ -207,7 +213,7 @@ namespace DesktopTool
             SendFrame(characteristicForSend, GattWriteOption.WriteWithoutResponse, frameBytes);
         }
 
-        private async void SendFrame(GattCharacteristic characteristicForSend, GattWriteOption writeOption, byte[] frameBytes)
+        protected async void SendFrame(GattCharacteristic characteristicForSend, GattWriteOption writeOption, byte[] frameBytes)
         {
             if (BLEservice == null) {
                 AppLogUtil.OutputLogDebug(string.Format("BLEService.SendFrame: service is null"));

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLEService.cs
@@ -12,15 +12,15 @@ namespace DesktopTool
     internal class BLEServiceParam
     {
         public Guid ServiceUUID { get; set; }
-        public Guid CharactForWriteUUID { get; set; }
-        public Guid CharactForReadUUID { get; set; }
+        public Guid CharacteristicForNotify { get; set; }
+        public Guid CharacteristicForSend { get; set; }
         public ulong BluetoothAddress { get; set; }
 
-        public BLEServiceParam(BLEPeripheralScannerParam param)
+        public BLEServiceParam(BLEPeripheralScannerParam param, string charForNotifyUUIDString, string charForSendUUIDString)
         {
             ServiceUUID = param.ServiceUUID;
-            CharactForWriteUUID = param.CharactForWriteUUID;
-            CharactForReadUUID = param.CharactForReadUUID;
+            CharacteristicForNotify = new Guid(charForNotifyUUIDString);
+            CharacteristicForSend = new Guid(charForSendUUIDString);
             BluetoothAddress = param.BluetoothAddress;
         }
     }
@@ -95,7 +95,7 @@ namespace DesktopTool
                     await Task.Run(() => System.Threading.Thread.Sleep(100));
                 }
 
-                CharacteristicForNotify = BLEservice.GetCharacteristics(parameter.CharactForWriteUUID)[0];
+                CharacteristicForNotify = BLEservice.GetCharacteristics(parameter.CharacteristicForNotify)[0];
                 if (await StartBLENotification(CharacteristicForNotify)) {
                     AppLogUtil.OutputLogInfo(string.Format("{0}({1})", MSG_BLE_U2F_NOTIFICATION_START, BLEservice.Device.Name));
                     return true;
@@ -202,9 +202,9 @@ namespace DesktopTool
         // 
         public virtual void SendFrame(byte[] frameBytes)
         {
-            // TODO: U2F固有の処理を別クラスに継承予定
-            GattCharacteristic U2FControlPointChar = BLEservice.GetCharacteristics(Parameter.CharactForReadUUID)[0];
-            SendFrame(U2FControlPointChar, GattWriteOption.WriteWithoutResponse, frameBytes);
+            // WriteWithoutResponse を既定オプションとして送信
+            GattCharacteristic characteristicForSend = BLEservice.GetCharacteristics(Parameter.CharacteristicForSend)[0];
+            SendFrame(characteristicForSend, GattWriteOption.WriteWithoutResponse, frameBytes);
         }
 
         private async void SendFrame(GattCharacteristic characteristicForSend, GattWriteOption writeOption, byte[] frameBytes)

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -9,6 +9,14 @@ namespace DesktopTool
         // ヘルパークラスの参照を保持
         protected BLEService BLEServiceRef = null!;
 
+        // プロパティー
+        public string CommandName { get; set; }
+
+        public BLETransport()
+        {
+            CommandName = string.Empty;
+        }
+
         //
         // 接続処理
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -171,7 +171,7 @@ namespace DesktopTool
         //
         public virtual void SendRequest(byte requestCMD, byte[] requestBytes)
         {
-            ResponseReceived(this, true, string.Empty, requestCMD, requestBytes);
+            FrameReceivedHandler(BLEServiceRef, true, string.Empty, requestBytes);
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -11,10 +11,12 @@ namespace DesktopTool
 
         // プロパティー
         public string CommandName { get; set; }
+        public bool NoOutputLog { get; set; }
 
         public BLETransport()
         {
             CommandName = string.Empty;
+            NoOutputLog = false;
         }
 
         //

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -23,7 +23,7 @@ namespace DesktopTool
             NotifyConnection += notifyConnectionHandler;
 
             // BLEデバイスをスキャン
-            BLEPeripheralScannerParam parameter = BLEPeripheralScannerParam.PrepareParameterForFIDO();
+            BLEPeripheralScannerParam parameter = new BLEPeripheralScannerParam(U2F_BLE_SERVICE_UUID_STR);
             new BLEPeripheralScanner().DoProcess(parameter, OnBLEPeripheralScanned);
         }
 
@@ -65,7 +65,7 @@ namespace DesktopTool
             AppLogUtil.OutputLogInfo(MSG_SCAN_BLE_DEVICE_SUCCESS);
 
             // サービスに接続
-            BLEServiceParam serviceParam = new BLEServiceParam(parameter);
+            BLEServiceParam serviceParam = new BLEServiceParam(parameter, U2F_STATUS_CHAR_UUID_STR, U2F_CONTROL_POINT_CHAR_UUID_STR);
             BLEService service = new BLEService();
             await service.StartCommunicate(serviceParam, OnConnectionStatusChanged);
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Helpers/BLETransport.cs
@@ -1,6 +1,4 @@
 ﻿using AppCommon;
-using System;
-using System.Linq;
 using static DesktopTool.BLEDefines;
 using static DesktopTool.HelperMessage;
 
@@ -9,7 +7,7 @@ namespace DesktopTool
     internal class BLETransport
     {
         // ヘルパークラスの参照を保持
-        private BLEService BLEServiceRef = null!;
+        protected BLEService BLEServiceRef = null!;
 
         //
         // 接続処理
@@ -70,8 +68,7 @@ namespace DesktopTool
 
         protected virtual void SetupBLEService(BLEPeripheralScannerParam parameter)
         {
-            // 接続サービスを設定し、サービスに接続
-            // TODO: U2F固有の処理を別クラスに継承予定
+            // U2Fサービスをデフォルトとして設定
             BLEServiceParam serviceParam = new BLEServiceParam(parameter, U2F_STATUS_CHAR_UUID_STR, U2F_CONTROL_POINT_CHAR_UUID_STR);
             BLEService service = new BLEService();
 
@@ -160,7 +157,7 @@ namespace DesktopTool
             ResponseReceived -= handler;
         }
 
-        private void OnResponseReceived(bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
+        protected void OnResponseReceived(bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
         {
             // コールバック設定を解除
             BLEServiceRef.UnregisterFrameReceivedHandler(FrameReceivedHandler);
@@ -172,182 +169,17 @@ namespace DesktopTool
         //
         // 送信処理
         //
-        public void SendRequest(byte requestCMD, byte[] requestBytes)
+        public virtual void SendRequest(byte requestCMD, byte[] requestBytes)
         {
-            // コールバックを設定
-            BLEServiceRef.RegisterFrameReceivedHandler(FrameReceivedHandler);
-
-            // APDUの長さを取得
-            int transferBytesLen = requestBytes.Length;
-            if (transferBytesLen == 0) {
-                // データ長０のフレームを送信
-                byte[] frame = new byte[] { requestCMD, 0, 0 };
-                BLEServiceRef.SendFrame(frame);
-                AppLogUtil.OutputLogDebug("BLE Sent INIT frame: data size=0");
-                return;
-            }
-
-            // 
-            // 送信データをフレーム分割
-            // 
-            //  INITフレーム
-            //  1     バイト目: コマンド
-            //  2 - 3 バイト目: データ長
-            //  残りのバイト  : データ部（64 - 3 = 61）
-            //
-            //  CONTフレーム
-            //  1     バイト目: シーケンス
-            //  残りのバイト  : データ部（64 - 1 = 63）
-            // 
-            byte[] frameData = new byte[U2F_BLE_FRAME_LEN];
-            int transferred = 0;
-            int seq = 0;
-            while (transferred < transferBytesLen) {
-                for (int j = 0; j < frameData.Length; j++) {
-                    // フレームデータを初期化
-                    frameData[j] = 0;
-                }
-
-                int frameLen;
-                if (transferred == 0) {
-                    // INITフレーム
-                    // ヘッダーをコピー
-                    frameData[0] = (byte)(0x80 | requestCMD);
-                    frameData[1] = (byte)(transferBytesLen / 256);
-                    frameData[2] = (byte)(transferBytesLen % 256);
-
-                    // データをコピー
-                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
-                    int dataLenInFrame = (transferBytesLen < maxLen) ? transferBytesLen : maxLen;
-                    for (int i = 0; i < dataLenInFrame; i++) {
-                        frameData[U2F_BLE_INIT_HEADER_LEN + i] = requestBytes[transferred++];
-                    }
-
-                    // フレーム長を取得
-                    frameLen = U2F_BLE_INIT_HEADER_LEN + dataLenInFrame;
-
-                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
-                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent INIT frame: data size={0} length={1}\r\n{2}",
-                        transferBytesLen, dataLenInFrame, dump));
-
-                } else {
-                    // CONTフレーム
-                    // ヘッダーをコピー
-                    frameData[0] = (byte)seq;
-
-                    // データをコピー
-                    int remaining = transferBytesLen - transferred;
-                    int maxLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
-                    int dataLenInFrame = (remaining < maxLen) ? remaining : maxLen;
-                    for (int i = 0; i < dataLenInFrame; i++) {
-                        frameData[U2F_BLE_CONT_HEADER_LEN + i] = requestBytes[transferred++];
-                    }
-
-                    // フレーム長を取得
-                    frameLen = U2F_BLE_CONT_HEADER_LEN + dataLenInFrame;
-
-                    string dump = AppLogUtil.DumpMessage(frameData, frameLen);
-                    AppLogUtil.OutputLogDebug(string.Format("BLE Sent CONT frame: data seq={0} length={1}\r\n{2}",
-                        seq++, dataLenInFrame, dump));
-                }
-
-                // BLEデバイスにフレームを送信
-                BLEServiceRef.SendFrame(frameData.Take(frameLen).ToArray());
-            }
+            ResponseReceived(this, true, string.Empty, requestCMD, requestBytes);
         }
 
         //
         // 受信処理（コールバック）
         //
-        private byte[] ReceivedResponse = Array.Empty<byte>();
-        private int ReceivedResponseLen = 0;
-        private int ReceivedSize = 0;
-
-        private void FrameReceivedHandler(BLEService service, bool success, string errorMessage, byte[] frameBytes)
+        protected virtual void FrameReceivedHandler(BLEService service, bool success, string errorMessage, byte[] frameBytes)
         {
-            if (success == false) {
-                OnResponseReceived(success, errorMessage, 0x00, Array.Empty<byte>());
-                return;
-            }
-
-            // 
-            // 受信したデータをバッファにコピー
-            // 
-            //  INITフレーム
-            //  1     バイト目: コマンド
-            //  2 - 3 バイト目: データ長
-            //  残りのバイト  : データ部（64 - 3 = 61）
-            //
-            //  CONTフレーム
-            //  1     バイト目: シーケンス
-            //  残りのバイト  : データ部（64 - 1 = 63）
-            // 
-            int bleInitDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_INIT_HEADER_LEN;
-            int bleContDataLen = U2F_BLE_FRAME_LEN - U2F_BLE_CONT_HEADER_LEN;
-            byte cmd = frameBytes[0];
-            if (cmd > 127) {
-                // INITフレームであると判断
-                byte cnth = frameBytes[1];
-                byte cntl = frameBytes[2];
-                ReceivedResponseLen = cnth * 256 + cntl;
-                ReceivedResponse = new byte[U2F_BLE_INIT_HEADER_LEN + ReceivedResponseLen];
-                ReceivedSize = 0;
-
-                // ヘッダーをコピー
-                for (int i = 0; i < U2F_BLE_INIT_HEADER_LEN; i++) {
-                    ReceivedResponse[i] = frameBytes[i];
-                }
-
-                // データをコピー
-                int dataLenInFrame = (ReceivedResponseLen < bleInitDataLen) ? ReceivedResponseLen : bleInitDataLen;
-                for (int i = 0; i < dataLenInFrame; i++) {
-                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_INIT_HEADER_LEN + i];
-                }
-
-                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
-                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD) == false) {
-                    // キープアライブ以外の場合はログを出力
-                    string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
-                    AppLogUtil.OutputLogDebug(string.Format(
-                        "BLE Recv INIT frame: data size={0} length={1}\r\n{2}",
-                        ReceivedResponseLen, dataLenInFrame, dump));
-                }
-
-            } else {
-                // CONTフレームであると判断
-                int seq = frameBytes[0];
-
-                // データをコピー
-                int remaining = ReceivedResponseLen - ReceivedSize;
-                int dataLenInFrame = (remaining < bleContDataLen) ? remaining : bleContDataLen;
-                for (int i = 0; i < dataLenInFrame; i++) {
-                    ReceivedResponse[U2F_BLE_INIT_HEADER_LEN + ReceivedSize++] = frameBytes[U2F_BLE_CONT_HEADER_LEN + i];
-                }
-
-                string dump = AppLogUtil.DumpMessage(frameBytes, frameBytes.Length);
-                AppLogUtil.OutputLogDebug(string.Format(
-                    "BLE Recv CONT frame: seq={0} length={1}\r\n{2}",
-                    seq, dataLenInFrame, dump));
-            }
-
-            // 全フレームがそろった場合
-            if (ReceivedSize == ReceivedResponseLen) {
-                // CMDを抽出
-                byte responseCMD = (byte)(ReceivedResponse[0] & 0x7f);
-                if (FunctionUtil.CommandIsU2FKeepAlive(responseCMD)) {
-                    // キープアライブの場合は引き続き次のレスポンスを待つ
-                    return;
-                }
-
-                // 受信データを転送
-                if (ReceivedResponseLen == 0) {
-                    OnResponseReceived(true, string.Empty, responseCMD, Array.Empty<byte>());
-
-                } else {
-                    byte[] response = ReceivedResponse.Skip(U2F_BLE_INIT_HEADER_LEN).ToArray();
-                    OnResponseReceived(true, string.Empty, responseCMD, response);
-                }
-            }
+            OnResponseReceived(success, errorMessage, 0x00, frameBytes);
         }
     }
 }

--- a/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
+++ b/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>VendorTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).008</FileVersion>
+    <FileVersion>$(Version).009</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
Windows版デスクトップツールに、BLEペアリング解除要求機能を本格実装します。

- BLEデバイスの現在ファームウェアバージョンを照会後、すでに実装済みのファームウェア更新進捗画面をポップアップ表示
（#22 ご参照）
- 同時に、ファームウェア更新イメージデータの転送をスタート
- 待機中に中止ボタンがクリックされた場合は、転送処理を途中で停止
- 転送を完了後、ファームウェア停止によるBLE切断を検知したら、ファームウェア再起動まで待機
 （秒数は３３秒と想定）
- 待機完了後、自動的にポップアップ画面を閉じ、転送処理を正常終了
 （待機中は中止ボタンがクリックできないようにします）
- 転送処理の正常終了後、BLEデバイスの更新後ファームウェアバージョンを照会し、処理を完了します。

<img width="400" src="https://github.com/makmorit/SquareDevices/assets/6850774/f63e1196-4e5c-4382-9274-9df1aefcd3fa">
