### PR TITLE
[Windows版ツール対応] PINGテスト実行機能の実装

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).011</FileVersion>
+    <FileVersion>$(Version).012</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTestQuery.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTestQuery.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using static DesktopTool.BLEDefines;
+using static DesktopTool.FunctionDefines;
+
+namespace DesktopTool
+{
+    internal class PingTestQuery
+    {
+        public const int PingBytesSize = 100;
+        public byte[] PingRequestBytes { get; private set; }
+        public byte[] PingResponseBytes { get; private set; }
+
+        public PingTestQuery()
+        {
+            PingRequestBytes = new byte[PingBytesSize];
+            PingResponseBytes = new byte[PingBytesSize];
+        }
+
+        //
+        // PINGテスト処理
+        //
+        public delegate void NotifyResponseQueryHandler(PingTestQuery sender, bool success, string errorMessage);
+        private event NotifyResponseQueryHandler NotifyResponseQuery = null!;
+
+        public void Inquiry(NotifyResponseQueryHandler notifyResponseQueryHandler, byte[] requestBytes)
+        {
+            // コールバックを設定
+            NotifyResponseQuery += notifyResponseQueryHandler;
+
+            // リクエストデータを保持
+            Array.Copy(requestBytes, PingRequestBytes, requestBytes.Length < PingBytesSize ? requestBytes.Length : PingBytesSize);
+
+            // BLEデバイスに接続
+            new BLEU2FTransport().Connect(OnNotifyConnection, U2F_BLE_SERVICE_UUID_STR);
+        }
+
+        private void OnNotifyConnection(BLETransport sender, bool success, string errorMessage)
+        {
+            if (success == false) {
+                // 失敗時は上位クラスに制御を戻す
+                NotifyResponseQuery?.Invoke(this, false, errorMessage);
+                NotifyResponseQuery = null!;
+                return;
+            }
+
+            // コールバックを登録
+            sender.RegisterResponseReceivedHandler(ResponseReceivedHandler);
+
+            // PINGテストコマンドを実行
+            PerformPingTestCommand(sender);
+        }
+
+        private void OnResponseInquiryCommand(BLETransport sender, byte[] responseBytes)
+        {
+            // 上位クラスに制御を戻す
+            TerminateCommand(sender, true, string.Empty);
+        }
+
+        //
+        // コールバック関数
+        //
+        private void ResponseReceivedHandler(BLETransport sender, bool success, string errorMessage, byte responseCMD, byte[] responseBytes)
+        {
+            // レスポンス受信失敗時はエラー扱い
+            if (success == false) {
+                TerminateCommand(sender, false, errorMessage);
+                return;
+            }
+
+            // レスポンスデータを保持
+            Array.Copy(responseBytes, PingResponseBytes, PingBytesSize);
+
+            // PINGレスポンスを、上位クラスに通知
+            OnResponseInquiryCommand(sender, responseBytes);
+        }
+
+        //
+        // 内部処理
+        //
+        private void PerformPingTestCommand(BLETransport sender)
+        {
+            // PINGテストコマンドを実行
+            sender.SendRequest(U2F_COMMAND_PING, PingRequestBytes);
+        }
+
+        //
+        // 終了処理
+        //
+        private void TerminateCommand(BLETransport sender, bool success, string message)
+        {
+            // コールバックを解除
+            sender.UnregisterResponseReceivedHandler(ResponseReceivedHandler);
+
+            // 切断処理
+            sender.Disconnect();
+
+            // 上位クラスに制御を戻す
+            NotifyResponseQuery?.Invoke(this, success, message);
+            NotifyResponseQuery = null!;
+        }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
@@ -1,0 +1,7 @@
+﻿namespace DesktopTool
+{
+    internal class PingTester : ToolDoProcess
+    {
+        public PingTester(string menuItemName) : base(menuItemName) { }
+    }
+}

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
@@ -1,5 +1,6 @@
-﻿using AppCommon;
-using System;
+﻿using System;
+using System.Threading.Tasks;
+using static DesktopTool.FunctionMessage;
 
 namespace DesktopTool
 {
@@ -12,7 +13,7 @@ namespace DesktopTool
         public PingTester(string menuItemName) : base(menuItemName) 
         {
             RandomInst = new Random();
-            PingBytes = new byte[100];
+            PingBytes = new byte[PingTestQuery.PingBytesSize];
         }
 
         protected override void InvokeProcessOnSubThread()
@@ -20,10 +21,52 @@ namespace DesktopTool
             // 100バイトのランダムデータを生成
             RandomInst.NextBytes(PingBytes);
 
-            // TODO: 仮の実装です。
-            string dump = AppLogUtil.DumpMessage(PingBytes, PingBytes.Length);
-            AppLogUtil.OutputLogDebug(string.Format("Ping bytes ({0} bytes)\r\n{1}", PingBytes.Length, dump));
-            PauseProcess(true);
+            // PINGテスト処理を実行
+            Task task = Task.Run(PerformPingTest);
+        }
+
+        private void PerformPingTest()
+        {
+            // PINGテスト処理を実行
+            new PingTestQuery().Inquiry(NotifyResponseQueryHandler, PingBytes);
+        }
+
+        private void NotifyResponseQueryHandler(PingTestQuery sender, bool success, string errorMessage)
+        {
+            if (success == false) {
+                // 失敗時はログ出力
+                TerminateCommand(false, errorMessage);
+                return;
+            }
+
+            // PINGバイトの一致チェック
+            for (int i = 0; i < PingBytes.Length; i++) {
+                if (PingBytes[i] != sender.PingResponseBytes[i]) {
+                    TerminateCommand(false, MSG_PING_TEST_INVALID_RESPONSE);
+                    return;
+                }
+            }
+
+            // 画面に制御を戻す
+            TerminateCommand(true, string.Empty);
+        }
+
+        //
+        // 終了処理
+        //
+        private void TerminateCommand(bool success, string message)
+        {
+            // 終了メッセージを画面表示／ログ出力
+            if (message.Length > 0) {
+                if (success) {
+                    LogAndShowInfoMessage(message);
+                } else {
+                    LogAndShowErrorMessage(message);
+                }
+            }
+
+            // 画面に制御を戻す
+            PauseProcess(success);
         }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/PingTester.cs
@@ -1,7 +1,29 @@
-﻿namespace DesktopTool
+﻿using AppCommon;
+using System;
+
+namespace DesktopTool
 {
     internal class PingTester : ToolDoProcess
     {
-        public PingTester(string menuItemName) : base(menuItemName) { }
+        // PINGバイトを保持
+        private Random RandomInst { get; set; }
+        private byte[] PingBytes { get; set; }
+
+        public PingTester(string menuItemName) : base(menuItemName) 
+        {
+            RandomInst = new Random();
+            PingBytes = new byte[100];
+        }
+
+        protected override void InvokeProcessOnSubThread()
+        {
+            // 100バイトのランダムデータを生成
+            RandomInst.NextBytes(PingBytes);
+
+            // TODO: 仮の実装です。
+            string dump = AppLogUtil.DumpMessage(PingBytes, PingBytes.Length);
+            AppLogUtil.OutputLogDebug(string.Format("Ping bytes ({0} bytes)\r\n{1}", PingBytes.Length, dump));
+            PauseProcess(true);
+        }
     }
 }

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionDefines.cs
@@ -6,6 +6,7 @@
         public const byte CTAP1_ERR_SUCCESS = 0x00;
 
         // U2Fコマンド
+        public const byte U2F_COMMAND_PING = 0x01;
         public const byte U2F_COMMAND_KEEPALIVE = 0x02;
         public const byte U2F_COMMAND_MSG = 0x03;
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionManager.cs
@@ -69,6 +69,9 @@ namespace DesktopTool
             } else if (menuItemName.Equals(MSG_MENU_ITEM_NAME_FIRMWARE_UPDATE)) {
                 new FWUpdate(menuItemName);
 
+            } else if (menuItemName.Equals(MSG_MENU_ITEM_NAME_PING_TEST)) {
+                new PingTester(menuItemName);
+
             } else if (menuItemName.Equals(MSG_MENU_ITEM_NAME_GET_FLASH_STAT)) {
                 new FWVersionInfo(menuItemName);
 

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/FunctionMessage.cs
@@ -71,6 +71,9 @@
         public const string MSG_FW_UPDATE_VERSION_FAIL = "ファームウェアのバージョンを{0}に更新できませんでした。";
         public const string MSG_FW_UPDATE_GET_IMAGE_VERSION_FROM_CONTEXT_FAIL = "ファームウェア更新イメージのバージョンを共有情報から取得できませんでした。";
 
+        // PINGテスト
+        public const string MSG_PING_TEST_INVALID_RESPONSE = "PINGテストのレスポンスが不正です。";
+
         // 現在時刻参照／設定
         public const string MSG_DEVICE_TIMESTAMP_CURRENT_DATETIME_FORMAT = "現在時刻：\n　ＰＣの時刻\t{0}\n　デバイスの時刻\t{1}";
         public const string MSG_DEVICE_TIMESTAMP_CURRENT_DATETIME_LOG_FORMAT = "現在時刻：ＰＣの時刻＝{0}、デバイスの時刻＝{1}";

--- a/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
+++ b/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
@@ -12,7 +12,7 @@
     <Company>makmorit</Company>
     <Product>VendorTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).011</FileVersion>
+    <FileVersion>$(Version).012</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
nRF5340基板に対し、PINGテストの実行機能を実装します。

下図メニューから実行する想定です。

<img src="https://github.com/makmorit/SquareDevices/assets/6850774/26002978-8ae4-4775-93bf-4926eff9c73a" width="400">

### PINGテストの仕様
下記リンクに掲載のPING機能を、nRF5340基板に搭載されているFIDO BLEトランスポートを経由して実行させます。
https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-ping