### PR TITLE
[障害] BLEペアリング失敗時にmacOS版デスクトップツールがハング

### DIFF
--- a/DesktopTools/macOS/DesktopToolFunctions/BLEConnection/BLEPairing.m
+++ b/DesktopTools/macOS/DesktopToolFunctions/BLEConnection/BLEPairing.m
@@ -61,6 +61,12 @@
     }
 
     - (void)scannedPeripheralDidConnectWithParam:(BLEPeripheralScannerParam *)parameter {
+        // 失敗時はログ出力
+        if ([parameter success] == false) {
+            [self LogAndShowErrorMessage:[parameter errorMessage]];
+            [self cancelProcess];
+            return;
+        }
         // ペアリングを成立させるため、U2F BLEサービスに接続
         BLEPeripheralRequesterParam *reqParam = [[BLEPeripheralRequesterParam alloc] initWithConnectedPeripheralRef:[parameter scannedCBPeripheralRef]];
         [reqParam setServiceUUIDString:U2F_BLE_SERVICE_UUID_STR];

--- a/DesktopTools/macOS/Helpers/BLEPeripheralScanner.m
+++ b/DesktopTools/macOS/Helpers/BLEPeripheralScanner.m
@@ -204,7 +204,13 @@
     - (void)centralManager:(CBCentralManager *)central didFailToConnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
         // 接続失敗を通知
         [[ToolLogFile defaultLogger] errorWithFormat:@"Connect peripheral failed: %@", error];
-        [self connectingDidTerminateWithParam:false withErrorMessage:MSG_CONNECT_BLE_DEVICE_FAILURE];
+        if ([[error domain] isEqualTo:CBErrorDomain] && [error code] == 14) {
+            // ペアリング情報消失によるエラーの場合
+            NSString *errorMessage = [NSString stringWithFormat:MSG_BLE_PARING_ERR_PAIRINF_REMOVED_BY_PEER, [peripheral name]];
+            [self connectingDidTerminateWithParam:false withErrorMessage:errorMessage];
+        } else {
+            [self connectingDidTerminateWithParam:false withErrorMessage:MSG_CONNECT_BLE_DEVICE_FAILURE];
+        }
     }
 
 #pragma mark - Disconnect from peripheral

--- a/DesktopTools/macOS/Helpers/HelperMessage.h
+++ b/DesktopTools/macOS/Helpers/HelperMessage.h
@@ -12,6 +12,7 @@
 #define MSG_BLE_PARING_ERR_BT_OFF                   @"Bluetoothがオフになっています。Bluetoothをオンにしてください。"
 #define MSG_BLE_PARING_ERR_TIMED_OUT                @"BLEデバイスが停止している可能性があります。BLEデバイスの電源を入れてください。"
 #define MSG_BLE_PARING_ERR_PROCESS                  @"BLEデバイスとのペアリング時にエラーが発生しました。"
+#define MSG_BLE_PARING_ERR_PAIRINF_REMOVED_BY_PEER  @"BLEデバイス側でペアリング情報が削除されました。macOSのBluetooth環境設定画面からデバイス(%@)を削除し、再度ペアリングを実行して下さい。"
 
 #pragma mark - BLEサービス
 #define MSG_BLE_U2F_NOTIFICATION_START              @"受信データの監視を開始します。"
@@ -29,7 +30,6 @@
 #define MSG_BLE_PERIPHERAL_SCAN_STOPPED             @"スキャンを停止しました。"
 
 #pragma mark - コマンド共通
-// コマンド共通
 #define MSG_ERROR_FUNCTION_IN_PAIRING_MODE          @"ペアリングモードでは、ペアリング実行以外の機能は使用できません。ペアリングモードを解除してから、機能を再度実行してください。"
 #define MSG_SCAN_BLE_DEVICE_SUCCESS                 @"対象のBLEデバイスがスキャンされました。"
 #define MSG_CONNECT_BLE_DEVICE_FAILURE              @"BLEデバイスの接続に失敗しました。"


### PR DESCRIPTION
## 概要
BLEペアリング情報がmacOS側に存在し、BLEデバイス側に存在しない場合、ツールがハングしてしまう不具合が確認されています。

<img src="https://github.com/makmorit/SquareDevices/assets/6850774/006bcb23-4e1b-474e-b6fd-cf0a5d144684" width="560">
