### PR TITLE
[障害] BLE状態が未確認にもかかわらず、機能ボタンがクリックできてしまう

### DIFF
--- a/DesktopTools/macOS/Functions/BLEConnection/BLEUnpairing.m
+++ b/DesktopTools/macOS/Functions/BLEConnection/BLEUnpairing.m
@@ -25,10 +25,17 @@
     - (instancetype)initWithDelegate:(id)delegate {
         self = [super initWithDelegate:delegate];
         if (self) {
+            [self enableClickButtonDoProcess:false];
             [self setTransport:[[BLEU2FTransport alloc] initWithDelegate:self]];
             [self setUnpairRequest:[[BLEUnpairRequest alloc] initWithDelegate:self]];
         }
         return self;
+    }
+
+    - (void)BLETransport:(BLETransport *)bleTransport didUpdateState:(bool)available {
+        if (available) {
+            [self enableClickButtonDoProcess:true];
+        }
     }
 
     - (void)invokeProcessOnSubQueue {

--- a/DesktopTools/macOS/Functions/BLEConnection/EraseBondingInfo.m
+++ b/DesktopTools/macOS/Functions/BLEConnection/EraseBondingInfo.m
@@ -22,9 +22,16 @@
     - (instancetype)initWithDelegate:(id)delegate {
         self = [super initWithDelegate:delegate];
         if (self) {
+            [self enableClickButtonDoProcess:false];
             [self setTransport:[[BLEU2FTransport alloc] initWithDelegate:self]];
         }
         return self;
+    }
+
+    - (void)BLETransport:(BLETransport *)bleTransport didUpdateState:(bool)available {
+        if (available) {
+            [self enableClickButtonDoProcess:true];
+        }
     }
 
 #pragma mark - Process management

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
@@ -32,17 +32,16 @@
         [self LogAndShowInfoMessage:MSG_FW_UPDATE_CURRENT_VERSION_CONFIRM];
 
         // BLEデバイスに接続し、ファームウェアのバージョン情報を取得
-        [[self fwVersion] commandWillInquiry];
+        [[self fwVersion] inquiry];
     }
 
-    // Callback from FWVersion
-    - (void)commandDidNotifyResponseQuery:(bool)success withErrorMessage:(NSString *)errorMessage {
+    - (void)FWVersion:(FWVersion *)fwVersion didNotifyResponseQuery:(bool)success withErrorMessage:(NSString *)errorMessage {
         if (success == false) {
             [self cancelCommand:success withErrorMessage:errorMessage];
             return;
         }
         // 更新ファームウェアのバージョンチェック／イメージ情報取得
-        [self setFwUpdateImage:[[FWUpdateImage alloc] initWithDelegate:self withVersionData:[[self fwVersion] versionData]]];
+        [self setFwUpdateImage:[[FWUpdateImage alloc] initWithDelegate:self withVersionData:[fwVersion versionData]]];
         [[self fwUpdateImage] commandWillRetrieveImage];
     }
 
@@ -53,7 +52,8 @@
             return;
         }
         // ファームウェアの現在バージョン／更新バージョンを画面表示
-        NSString *fwRev = [[[self fwVersion] versionData] fwRev];
+        // NSString *fwRev = [[[self fwVersion] versionData] fwRev];
+        NSString *fwRev = @""; // 移行措置
         NSString *updateVersion = [[[self fwUpdateImage] updateImageData] updateVersion];
         NSString *message = [NSString stringWithFormat:MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, fwRev, updateVersion];
         [self LogAndShowInfoMessage:message];

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
@@ -13,7 +13,6 @@
     // 上位クラスの参照を保持
     @property (nonatomic) id                            delegate;
     @property (nonatomic) FWVersion                    *fwVersion;
-    @property (nonatomic) FWUpdateImage                *fwUpdateImage;
 
 @end
 
@@ -41,12 +40,10 @@
             return;
         }
         // 更新ファームウェアのバージョンチェック／イメージ情報取得
-        [self setFwUpdateImage:[[FWUpdateImage alloc] initWithDelegate:self withVersionData:[fwVersion versionData]]];
-        [[self fwUpdateImage] commandWillRetrieveImage];
+        [[[FWUpdateImage alloc] initWithDelegate:self withVersionData:[fwVersion versionData]] retrieveImage];
     }
 
-    // Callback from FWUpdateImage
-    - (void)commandDidRetrieveImage:(bool)success withErrorMessage:(NSString *)errorMessage {
+    - (void)FWUpdateImage:(FWUpdateImage *)fwUpdateImage didRetrieveImage:(bool)success withErrorMessage:(NSString *)errorMessage {
         if (success == false) {
             [self cancelCommand:success withErrorMessage:errorMessage];
             return;
@@ -54,7 +51,7 @@
         // ファームウェアの現在バージョン／更新バージョンを画面表示
         // NSString *fwRev = [[[self fwVersion] versionData] fwRev];
         NSString *fwRev = @""; // 移行措置
-        NSString *updateVersion = [[[self fwUpdateImage] updateImageData] updateVersion];
+        NSString *updateVersion = [[fwUpdateImage updateImageData] updateVersion];
         NSString *message = [NSString stringWithFormat:MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, fwRev, updateVersion];
         [self LogAndShowInfoMessage:message];
         // TODO: 仮の実装です。

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
@@ -49,8 +49,7 @@
             return;
         }
         // ファームウェアの現在バージョン／更新バージョンを画面表示
-        // NSString *fwRev = [[[self fwVersion] versionData] fwRev];
-        NSString *fwRev = @""; // 移行措置
+        NSString *fwRev = [fwUpdateImage currentVersion];
         NSString *updateVersion = [[fwUpdateImage updateImageData] updateVersion];
         NSString *message = [NSString stringWithFormat:MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, fwRev, updateVersion];
         [self LogAndShowInfoMessage:message];

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
@@ -21,9 +21,16 @@
     - (instancetype)initWithDelegate:(id)delegate {
         self = [super initWithDelegate:delegate];
         if (self) {
+            [self enableClickButtonDoProcess:false];
             [self setFwVersion:[[FWVersion alloc] initWithDelegate:self]];
         }
         return self;
+    }
+
+    - (void)FWVersion:(FWVersion *)fwVersion didUpdateState:(bool)available {
+        if (available) {
+            [self enableClickButtonDoProcess:true];
+        }
     }
 
     - (void)invokeProcessOnSubQueue {

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdate.m
@@ -54,7 +54,7 @@
         NSString *message = [NSString stringWithFormat:MSG_FW_UPDATE_CURRENT_VERSION_DESCRIPTION, fwRev, updateVersion];
         [self LogAndShowInfoMessage:message];
         // TODO: 仮の実装です。
-        [self terminateCommand:success withMessage:nil];
+        [self terminateCommand:success withMessage:@"to be continued..."];
     }
 
 #pragma mark - 終了処理

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.h
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.h
@@ -23,6 +23,7 @@
 
     - (instancetype)initWithDelegate:(id)delegate withVersionData:(id)versionDataRef;
     - (void)retrieveImage;
+    - (NSString *)currentVersion;
 
 @end
 

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.h
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.h
@@ -22,13 +22,13 @@
     @property (nonatomic) FWUpdateImageData    *updateImageData;
 
     - (instancetype)initWithDelegate:(id)delegate withVersionData:(id)versionDataRef;
-    - (void)commandWillRetrieveImage;
+    - (void)retrieveImage;
 
 @end
 
 @protocol FWUpdateImageDelegate <NSObject>
 
-    - (void)commandDidRetrieveImage:(bool)success withErrorMessage:(NSString *)errorMessage;
+    - (void)FWUpdateImage:(FWUpdateImage *)fwUpdateImage didRetrieveImage:(bool)success withErrorMessage:(NSString *)errorMessage;
 
 @end
 

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.m
@@ -38,7 +38,7 @@
         return self;
     }
 
-    - (void)commandWillRetrieveImage {
+    - (void)retrieveImage {
         // 基板名に対応するファームウェア更新イメージファイルから、バイナリーイメージを読込
         if ([self readFWUpdateImageFile:[[self versionData] hwRev]] == false) {
             [self terminate:false withErrorMessage:MSG_FW_UPDATE_IMAGE_FILE_NOT_EXIST];
@@ -97,7 +97,7 @@
     }
 
     - (void)terminate:(bool)success withErrorMessage:(NSString *)errorMessage {
-        [[self delegate] commandDidRetrieveImage:success withErrorMessage:errorMessage];
+        [[self delegate] FWUpdateImage:self didRetrieveImage:success withErrorMessage:errorMessage];
     }
 
 @end

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWUpdateImage.m
@@ -38,6 +38,11 @@
         return self;
     }
 
+    - (NSString *)currentVersion {
+        // BLE経由で取得した現在バージョンを戻す
+        return [[self versionData] fwRev];
+    }
+
     - (void)retrieveImage {
         // 基板名に対応するファームウェア更新イメージファイルから、バイナリーイメージを読込
         if ([self readFWUpdateImageFile:[[self versionData] hwRev]] == false) {

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.h
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.h
@@ -31,6 +31,7 @@
 
 @protocol FWVersionDelegate <NSObject>
 
+    - (void)FWVersion:(FWVersion *)fwVersion didUpdateState:(bool)available;
     - (void)FWVersion:(FWVersion *)fwVersion didNotifyResponseQuery:(bool)success withErrorMessage:(NSString *)errorMessage;
 
 @end

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.h
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.h
@@ -25,13 +25,13 @@
     @property (nonatomic) FWVersionData        *versionData;
 
     - (instancetype)initWithDelegate:(id)delegate;
-    - (void)commandWillInquiry;
+    - (void)inquiry;
 
 @end
 
 @protocol FWVersionDelegate <NSObject>
 
-    - (void)commandDidNotifyResponseQuery:(bool)success withErrorMessage:(NSString *)errorMessage;
+    - (void)FWVersion:(FWVersion *)fwVersion didNotifyResponseQuery:(bool)success withErrorMessage:(NSString *)errorMessage;
 
 @end
 

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.m
@@ -42,6 +42,10 @@
         return self;
     }
 
+    - (void)BLETransport:(BLETransport *)bleTransport didUpdateState:(bool)available {
+        [[self delegate] FWVersion:self didUpdateState:available];
+    }
+
     - (void)inquiry {
         // U2F BLEサービスに接続
         [[self transport] transportWillConnect];

--- a/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.m
+++ b/DesktopTools/macOS/Functions/DeviceMaintenance/FWVersion.m
@@ -42,7 +42,7 @@
         return self;
     }
 
-    - (void)commandWillInquiry {
+    - (void)inquiry {
         // U2F BLEサービスに接続
         [[self transport] transportWillConnect];
     }
@@ -50,7 +50,7 @@
     - (void)transportDidConnect:(bool)success withErrorMessage:(NSString *)errorMessage {
         if (success == false) {
             // U2F BLEサービスに接続失敗時
-            [[self delegate] commandDidNotifyResponseQuery:false withErrorMessage:errorMessage];
+            [[self delegate] FWVersion:self didNotifyResponseQuery:false withErrorMessage:errorMessage];
             return;
         }
         // バージョン照会コマンドを実行
@@ -91,7 +91,7 @@
     - (void)disconnectAndTerminateCommand:(bool)success withErrorMessage:(NSString *)errorMessage {
         // BLE接続を切断し、制御を戻す
         [[self transport] transportWillDisconnect];
-        [[self delegate] commandDidNotifyResponseQuery:success withErrorMessage:errorMessage];
+        [[self delegate] FWVersion:self didNotifyResponseQuery:success withErrorMessage:errorMessage];
     }
 
 #pragma mark - Perform command

--- a/DesktopTools/macOS/Helpers/BLETransport.h
+++ b/DesktopTools/macOS/Helpers/BLETransport.h
@@ -28,6 +28,7 @@
 
 @protocol BLETransportDelegate <NSObject>
 
+    - (void)BLETransport:(BLETransport *)bleTransport didUpdateState:(bool)available;
     - (void)transportDidConnect:(bool)success withErrorMessage:(NSString *)errorMessage;
     - (void)transportDidReceiveResponse:(bool)success withErrorMessage:(NSString *)errorMessage withCMD:(uint8_t)responseCMD withData:(NSData *)responseData;
 

--- a/DesktopTools/macOS/Helpers/BLETransport.m
+++ b/DesktopTools/macOS/Helpers/BLETransport.m
@@ -35,6 +35,7 @@
 
     // Callback from BLEPeripheralScanner
     - (void)didUpdateScannerState:(bool)available {
+        [[self delegate] BLETransport:self didUpdateState:available];
     }
 
 #pragma mark - Public functions


### PR DESCRIPTION
## 概要
macOS版デスクトップツールにおける一部機能で、BLE状態（使用可能／不可能）がプログラムによって確認されていないにもかかわらず、機能ボタン（下図「実行」ボタン）がクリックできてしまう不具合が確認されています。

<img src="https://github.com/makmorit/SquareDevices/assets/6850774/11c33673-b4f4-4e12-b102-6aeebd77f102" width="400">

　
BLE状態がプログラムによって確認されるまで、実行ボタンをクリックできないようにする制御を、追加実装する必要があります。

### 影響のある機能
- ペアリング解除要求
- ペアリング情報削除
- ファームウェア更新（現在実装中）
