### PR TITLE
[Windows版ツール対応] ファームウェア更新処理の修正

### DIFF
--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <Version>0.0.1</Version>
+    <Version>0.1.0</Version>
     <Copyright>Copyright © 2023-2024 makmorit</Copyright>
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -8,11 +8,11 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
     <Version>0.0.1</Version>
-    <Copyright>Copyright © 2023 makmorit</Copyright>
+    <Copyright>Copyright © 2023-2024 makmorit</Copyright>
     <Company>makmorit</Company>
     <Product>DesktopTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).013</FileVersion>
+    <FileVersion>$(Version).014</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/DesktopTool.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\app_update.PCA10095_01.0.0.2.bin" />
+    <EmbeddedResource Include="Resources\app_update.PCA10095_01.0.0.4.bin" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateCBORDecoder.cs
+++ b/DesktopTools/dotNET/DesktopToolApp/DesktopToolApp/Functions/DeviceMaintenance/FWUpdateCBORDecoder.cs
@@ -74,6 +74,18 @@ namespace DesktopTool
             // Map内を探索
             foreach (CBORObject uploadResultInfoKey in uploadResultInfoMap.Keys) {
                 string keyStr = uploadResultInfoKey.AsString();
+                if (keyStr.Equals("off")) {
+                    // "off"エントリーを抽出（数値）
+                    UInt32 off = 0;
+                    if (ParseUInt32Value(uploadResultInfoMap, uploadResultInfoKey, ref off) == false) {
+                        return false;
+                    }
+                    // "off"エントリーが存在する場合は正常終了扱い
+                    // （他のエントリーが存在しない仕様）
+                    ResultInfo.Off = off;
+                    ResultInfo.Rc = 0;
+                    return true;
+                }
                 if (keyStr.Equals("rc")) {
                     // "rc"エントリーを抽出（数値）
                     byte rc = 0;
@@ -81,14 +93,6 @@ namespace DesktopTool
                         return false;
                     }
                     ResultInfo.Rc = rc;
-                }
-                if (keyStr.Equals("off")) {
-                    // "off"エントリーを抽出（数値）
-                    UInt32 off = 0;
-                    if (ParseUInt32Value(uploadResultInfoMap, uploadResultInfoKey, ref off) == false) {
-                        return false;
-                    }
-                    ResultInfo.Off = off;
                 }
             }
             return true;

--- a/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
+++ b/DesktopTools/dotNET/VendorToolApp/VendorTool/VendorTool.csproj
@@ -8,11 +8,11 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
     <Version>0.0.1</Version>
-    <Copyright>Copyright © 2023 makmorit</Copyright>
+    <Copyright>Copyright © 2023-2024 makmorit</Copyright>
     <Company>makmorit</Company>
     <Product>VendorTool</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <FileVersion>$(Version).013</FileVersion>
+    <FileVersion>$(Version).014</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
#52 で対応した[nCS v2.5.2](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.5.2/nrf/index.html)へのバージョンアップに伴い、ファームウェア更新処理（BLE SMPサービス）の仕様が変更となりました。
このため、デスクトップツールにおけるファームウェア更新処理の実装を、nCS側の仕様変更に追従させます。
