### PR TITLE
[ファーム対応] バージョン依存コードの移行

### DIFF
--- a/nRF5340FW/square_devices_app/westbuild.sh
+++ b/nRF5340FW/square_devices_app/westbuild.sh
@@ -5,9 +5,9 @@
 export BUILD_TARGET=nrf5340dk_nrf5340_cpuapp
 
 # Environment variables for Zephyr SDK
-export ZEPHYR_SDK_INSTALL_DIR="${HOME}/opt/zephyr-sdk-0.16.1"
+export ZEPHYR_SDK_INSTALL_DIR="${HOME}/opt/zephyr-sdk-0.16.5"
 export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-export ZEPHYR_TOOLCHAIN_PATH="${HOME}/opt/zephyr-sdk-0.16.1"
+export ZEPHYR_TOOLCHAIN_PATH="${HOME}/opt/zephyr-sdk-0.16.5"
 
 # Paths for command
 export PATH=${PATH}:/usr/local/bin
@@ -16,7 +16,7 @@ export PATH=${PATH}:/usr/local/bin
 export FWLIB_PATH=../../Firmwares
 
 # bash completion
-export NCS_HOME=${HOME}/opt/ncs_2.5.2
+export NCS_HOME=${HOME}/opt/ncs_2.6.1
 export ZEPHYR_BASE=${NCS_HOME}/zephyr
 source ${ZEPHYR_BASE}/zephyr-env.sh
 


### PR DESCRIPTION
## 概要
[nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.5.2/nrf/index.html)のバージョンアップ（v2.5.2-->v2.6.1）に伴い、nRF5340ファームウェアのバージョン依存コードを見直します。

- ビルドに使用するZephyr SDKのバージョンを0.16.1 --> 0.16.5に変更
- ビルドに使用するnCSのバージョンを2.5.2 --> 2.6.1に変更
- ファームウェアのベースになったサンプルアプリ（`bluetooth/peripheral_dis`、`mcumgr/smp_svr`）の修正影響は、2024/6/13現在では確認されていません。